### PR TITLE
lateinit-internal-fix: Fixed the initialization order of the content …

### DIFF
--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
@@ -197,6 +197,9 @@ internal object ApphudInternal {
         allowIdentifyUser = false
         this.observerMode = observerMode
 
+        this.context = context.applicationContext
+        this.apiKey = apiKey
+
         mainScope.launch {
             ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleEventObserver)
         }
@@ -204,8 +207,6 @@ internal object ApphudInternal {
         ApphudLog.log("Start initialization with userId=$inputUserId, deviceId=$inputDeviceId")
         if (apiKey.isEmpty()) throw Exception("ApiKey can't be empty")
 
-        this.context = context.applicationContext
-        this.apiKey = apiKey
         val isValid = storage.validateCaches()
         if (ignoreCache) {
             ApphudLog.logI("Ignoring local paywalls cache")


### PR DESCRIPTION
…and apiKey fields

I moved the assignment of context and apiKey to using these fields in the initialization logic to avoid possible errors when accessing uninitialized values. This increases the reliability of initialization of the class.