### PR TITLE
WIP: Refactor: Centralize user management and persistence

### DIFF
--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Attribution.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Attribution.kt
@@ -14,6 +14,7 @@ import com.apphud.sdk.domain.AdjustInfo
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.domain.AppsflyerInfo
 import com.apphud.sdk.domain.FacebookInfo
+import com.apphud.sdk.internal.ServiceLocator
 import com.apphud.sdk.internal.data.dto.AttributionRequestDto
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
@@ -28,7 +29,7 @@ internal fun ApphudInternal.setAttribution(
 ) {
     when (provider) {
         APPSFLYER -> {
-            val temporary = storage.appsflyer
+            val temporary = ServiceLocator.instance.sharedPreferencesStorage.appsflyer
             when {
                 temporary == null -> Unit
                 (temporary.id == identifier) && (temporary.data == apphudAttributionData.rawData) -> {
@@ -38,7 +39,7 @@ internal fun ApphudInternal.setAttribution(
             }
         }
         FACEBOOK -> {
-            val temporary = storage.facebook
+            val temporary = ServiceLocator.instance.sharedPreferencesStorage.facebook
             when {
                 temporary == null -> Unit
                 temporary.data == apphudAttributionData.rawData -> {
@@ -48,13 +49,13 @@ internal fun ApphudInternal.setAttribution(
             }
         }
         FIREBASE -> {
-            if (storage.firebase == identifier) {
+            if (ServiceLocator.instance.sharedPreferencesStorage.firebase == identifier) {
                 ApphudLog.logI("Already submitted the same Firebase attribution, skipping")
                 return
             }
         }
         ADJUST -> {
-            val temporary = storage.adjust
+            val temporary = ServiceLocator.instance.sharedPreferencesStorage.adjust
             when {
                 temporary == null -> Unit
                 (temporary.adid == identifier) && (temporary.adjustData == apphudAttributionData.rawData) -> {
@@ -115,22 +116,23 @@ internal fun ApphudInternal.setAttribution(
                 withContext(Dispatchers.Main) {
                     when (provider) {
                         APPSFLYER -> {
-                            storage.appsflyer = AppsflyerInfo(
+                            ServiceLocator.instance.sharedPreferencesStorage.appsflyer = AppsflyerInfo(
                                 id = identifier,
                                 data = apphudAttributionData.rawData,
                             )
                         }
 
                         FACEBOOK -> {
-                            storage.facebook = FacebookInfo(apphudAttributionData.rawData)
+                            ServiceLocator.instance.sharedPreferencesStorage.facebook =
+                                FacebookInfo(apphudAttributionData.rawData)
                         }
 
                         FIREBASE -> {
-                            storage.firebase = identifier
+                            ServiceLocator.instance.sharedPreferencesStorage.firebase = identifier
                         }
 
                         ADJUST -> {
-                            storage.adjust = AdjustInfo(
+                            ServiceLocator.instance.sharedPreferencesStorage.adjust = AdjustInfo(
                                 adid = identifier,
                                 adjustData = apphudAttributionData.rawData,
                             )

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
@@ -22,11 +22,11 @@ internal var processedFallbackData = false
 internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
     try {
         if (currentUser == null) {
-            currentUser =
-                ApphudUser(
-                    userId, "", "", listOf(), listOf(), listOf(),
-                    listOf(), true,
-                )
+            val tempUser = ApphudUser(
+                userId, "", "", listOf(), listOf(), listOf(),
+                listOf(), true,
+            )
+            kotlinx.coroutines.runBlocking { userRepository.updateUser(tempUser) }
             ApphudLog.log("Fallback: user created: $userId")
         }
 

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.domain.FallbackJsonObject
+import com.apphud.sdk.internal.ServiceLocator
 import com.apphud.sdk.mappers.PaywallsMapperLegacy
 import com.apphud.sdk.parser.GsonParser
 import com.apphud.sdk.parser.Parser
@@ -112,7 +113,7 @@ internal fun ApphudInternal.disableFallback() {
             ApphudLog.log("Fallback: reload products")
             loadProducts()
         }
-        if (storage.isNeedSync) {
+        if (ServiceLocator.instance.sharedPreferencesStorage.isNeedSync) {
             syncPurchases()
         }
     }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
@@ -6,6 +6,7 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.apphud.sdk.domain.ApphudProduct
 import com.apphud.sdk.domain.PurchaseRecordDetails
+import com.apphud.sdk.internal.ServiceLocator
 import com.apphud.sdk.internal.callback_status.PurchaseHistoryCallbackStatus
 import com.apphud.sdk.internal.callback_status.PurchaseRestoredCallbackStatus
 import com.apphud.sdk.internal.util.runCatchingCancellable
@@ -101,7 +102,7 @@ internal suspend fun ApphudInternal.syncPurchases(
 
         if (purchases.isEmpty()) {
             ApphudLog.log(message = "SyncPurchases: Nothing to restore")
-            storage.isNeedSync = false
+            ServiceLocator.instance.sharedPreferencesStorage.isNeedSync = false
             refreshEntitlements(true)
             val user = currentUser
             return if (user != null) {
@@ -146,7 +147,7 @@ internal suspend fun ApphudInternal.syncPurchases(
 
             if (prevPurchases.containsAll(restoredPurchases)) {
                 ApphudLog.log("SyncPurchases: Don't send equal purchases from prev state")
-                storage.isNeedSync = false
+                ServiceLocator.instance.sharedPreferencesStorage.isNeedSync = false
                 mainScope.launch {
                     refreshEntitlements(true)
                 }
@@ -210,7 +211,7 @@ internal suspend fun ApphudInternal.sendPurchasesToApphud(
                 ApphudLog.log("SyncPurchases: customer was successfully updated $customer")
             }
 
-            storage.isNeedSync = false
+            ServiceLocator.instance.sharedPreferencesStorage.isNeedSync = false
             prevPurchases.addAll(tempPurchaseRecordDetails)
 
             userId = customer.userId

--- a/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
@@ -42,6 +42,8 @@ internal class ServiceLocator(
 
     private val gson: Gson = Gson()
 
+    val sharedPreferencesStorage: SharedPreferencesStorage = SharedPreferencesStorage(applicationContext)
+
     private val paywallsMapper = PaywallsMapper(gson)
     private val placementsMapper = PlacementsMapper(paywallsMapper)
     private val subscriptionMapper = SubscriptionMapper()
@@ -49,7 +51,7 @@ internal class ServiceLocator(
         CustomerMapper(subscriptionMapper, paywallsMapper, placementsMapper)
 
     private val registrationProvider: RegistrationProvider =
-        RegistrationProvider(applicationContext, SharedPreferencesStorage)
+        RegistrationProvider(applicationContext, sharedPreferencesStorage)
 
     private val okHttpClient: OkHttpClient =
         OkHttpClient.Builder()
@@ -112,7 +114,7 @@ internal class ServiceLocator(
 
     private val lifecycleRepository: LifecycleRepository = LifecycleRepository()
 
-    val userRepository: UserRepository = UserRepository(SharedPreferencesStorage)
+    val userRepository: UserRepository = UserRepository(sharedPreferencesStorage)
 
     val userRemoteRepository: UserRemoteRepository =
         UserRemoteRepository(

--- a/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
@@ -5,6 +5,7 @@ import com.apphud.sdk.ApphudInternal
 import com.apphud.sdk.ApphudRuleCallback
 import com.apphud.sdk.internal.data.local.LifecycleRepository
 import com.apphud.sdk.internal.data.local.LocalRulesScreenRepository
+import com.apphud.sdk.internal.data.local.UserRepository
 import com.apphud.sdk.internal.data.mapper.CustomerMapper
 import com.apphud.sdk.internal.data.mapper.PaywallsMapper
 import com.apphud.sdk.internal.data.mapper.PlacementsMapper
@@ -21,6 +22,7 @@ import com.apphud.sdk.internal.data.remote.ScreenRemoteRepository
 import com.apphud.sdk.internal.data.remote.UserRemoteRepository
 import com.apphud.sdk.internal.domain.FetchMostActualRuleScreenUseCase
 import com.apphud.sdk.internal.domain.FetchRulesScreenUseCase
+import com.apphud.sdk.internal.domain.UpdateCustomerUseCase
 import com.apphud.sdk.internal.domain.mapper.DateTimeMapper
 import com.apphud.sdk.internal.domain.mapper.NotificationMapper
 import com.apphud.sdk.internal.domain.model.ApiKey
@@ -98,7 +100,6 @@ internal class ServiceLocator(
     private val screenRemoteRepository: ScreenRemoteRepository =
         ScreenRemoteRepository(
             okHttpClient = okHttpClientWithoutHeaders,
-            gson = gson,
             apiKey = apiKey
         )
 
@@ -109,7 +110,9 @@ internal class ServiceLocator(
             ruleScreenMapper = RuleScreenMapper()
         )
 
-    val lifecycleRepository: LifecycleRepository = LifecycleRepository()
+    private val lifecycleRepository: LifecycleRepository = LifecycleRepository()
+
+    val userRepository: UserRepository = UserRepository(SharedPreferencesStorage)
 
     val userRemoteRepository: UserRemoteRepository =
         UserRemoteRepository(
@@ -130,6 +133,10 @@ internal class ServiceLocator(
         FetchMostActualRuleScreenUseCase(
             localRulesScreenRepository = localRulesScreenRepository,
         )
+
+    val updateCustomerUseCase: UpdateCustomerUseCase = UpdateCustomerUseCase(
+        userRepository = userRepository,
+    )
 
     val ruleController: RuleController =
         RuleController(

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/local/UserRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/local/UserRepository.kt
@@ -5,6 +5,7 @@ import com.apphud.sdk.storage.Storage
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -23,14 +24,14 @@ internal class UserRepository(
 
     suspend fun getCurrentUser(): ApphudUser? {
         return userMutex.withLock {
-            _currentUser.replayCache.first()
+            _currentUser.firstOrNull()
         }
     }
 
     suspend fun updateUser(user: ApphudUser) {
         userMutex.withLock {
             storage.apphudUser = user
-            user.let { storage.userId = it.userId }
+//            user.let { storage.userId = it.userId }
             _currentUser.tryEmit(user)
         }
     }
@@ -39,7 +40,7 @@ internal class UserRepository(
     suspend fun clearUser() {
         userMutex.withLock {
             storage.apphudUser = null
-            storage.userId = null
+//            storage.userId = null
             _currentUser.tryEmit(null)
         }
     }

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/local/UserRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/local/UserRepository.kt
@@ -1,0 +1,46 @@
+package com.apphud.sdk.internal.data.local
+
+import com.apphud.sdk.domain.ApphudUser
+import com.apphud.sdk.storage.Storage
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class UserRepository(
+    private val storage: Storage,
+) {
+    private val userMutex = Mutex()
+
+    private val _currentUser = MutableSharedFlow<ApphudUser?>(replay = 1)
+    val currentUserFlow: SharedFlow<ApphudUser?> = _currentUser.asSharedFlow()
+
+    init {
+        val cachedUser = storage.apphudUser
+        _currentUser.tryEmit(cachedUser)
+    }
+
+    suspend fun getCurrentUser(): ApphudUser? {
+        return userMutex.withLock {
+            _currentUser.replayCache.first()
+        }
+    }
+
+    suspend fun updateUser(user: ApphudUser) {
+        userMutex.withLock {
+            storage.apphudUser = user
+            user.let { storage.userId = it.userId }
+            _currentUser.tryEmit(user)
+        }
+    }
+
+
+    suspend fun clearUser() {
+        userMutex.withLock {
+            storage.apphudUser = null
+            storage.userId = null
+            _currentUser.tryEmit(null)
+        }
+    }
+} 

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/ScreenRemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/ScreenRemoteRepository.kt
@@ -5,7 +5,6 @@ import com.apphud.sdk.ApphudError
 import com.apphud.sdk.ApphudLog
 import com.apphud.sdk.internal.domain.model.ApiKey
 import com.apphud.sdk.internal.util.runCatchingCancellable
-import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -14,7 +13,6 @@ import java.util.Locale
 
 internal class ScreenRemoteRepository(
     private val okHttpClient: OkHttpClient,
-    private val gson: Gson,
     private val apiKey: ApiKey,
 ) {
 

--- a/sdk/src/main/java/com/apphud/sdk/internal/domain/UpdateCustomerUseCase.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/domain/UpdateCustomerUseCase.kt
@@ -1,0 +1,18 @@
+package com.apphud.sdk.internal.domain
+
+import com.apphud.sdk.domain.ApphudUser
+import com.apphud.sdk.internal.data.local.UserRepository
+
+internal class UpdateCustomerUseCase(
+    private val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke(apphudUser: ApphudUser): Boolean {
+        val previousUser = userRepository.getCurrentUser()
+        val userIdChanged = previousUser?.userId != apphudUser.userId
+
+        userRepository.updateUser(apphudUser)
+
+        return userIdChanged
+    }
+} 

--- a/sdk/src/main/java/com/apphud/sdk/managers/RequestManager.kt
+++ b/sdk/src/main/java/com/apphud/sdk/managers/RequestManager.kt
@@ -52,7 +52,6 @@ internal object RequestManager {
     // TODO to be settled
     private var apiKey: String? = null
     lateinit var applicationContext: Context
-    internal lateinit var storage: SharedPreferencesStorage
     var previousException: java.lang.Exception? = null
     var retries: Int = 0
 
@@ -62,7 +61,6 @@ internal object RequestManager {
     ) {
         this.applicationContext = applicationContext
         apiKey?.let { this.apiKey = it }
-        this.storage = SharedPreferencesStorage
     }
 
     fun cleanRegistration() {

--- a/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
+++ b/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
@@ -19,41 +19,10 @@ import com.apphud.sdk.parser.Parser
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
 
-internal object SharedPreferencesStorage : Storage {
-    private var cacheTimeout: Long = 90000L
-
-    fun getInstance(applicationContext: Context): SharedPreferencesStorage {
-        this.applicationContext = applicationContext
-        preferences = SharedPreferencesStorage.applicationContext.getSharedPreferences(NAME, Context.MODE_PRIVATE)
-        this.cacheTimeout = if (SharedPreferencesStorage.applicationContext.isDebuggable()) 60L else 90000L // 25 hours
-        return this
-    }
-
-    private lateinit var applicationContext: Context
-
-    private lateinit var preferences: SharedPreferences
-    private const val NAME = "apphud_storage"
-
-    private const val USER_ID_KEY = "userIdKey"
-    private const val APPHUD_USER_KEY = "APPHUD_USER_KEY"
-    private const val DEVICE_ID_KEY = "deviceIdKey"
-    private const val DEVICE_IDENTIFIERS_KEY = "DEVICE_IDENTIFIERS_KEY"
-    private const val NEED_RESTART_KEY = "needRestartKey"
-    private const val PROPERTIES_KEY = "propertiesKey"
-    private const val FACEBOOK_KEY = "facebookKey"
-    private const val FIREBASE_KEY = "firebaseKey"
-    private const val APPSFLYER_KEY = "appsflyerKey"
-    private const val ADJUST_KEY = "adjustKey"
-    private const val PAYWALLS_KEY = "PAYWALLS_KEY"
-    private const val PAYWALLS_TIMESTAMP_KEY = "PAYWALLS_TIMESTAMP_KEY"
-    private const val PLACEMENTS_KEY = "PLACEMENTS_KEY"
-    private const val PLACEMENTS_TIMESTAMP_KEY = "PLACEMENTS_TIMESTAMP_KEY"
-    private const val GROUP_KEY = "apphudGroupKey"
-    private const val GROUP_TIMESTAMP_KEY = "apphudGroupTimestampKey"
-    private const val SKU_KEY = "skuKey"
-    private const val SKU_TIMESTAMP_KEY = "skuTimestampKey"
-    private const val LAST_REGISTRATION_KEY = "lastRegistrationKey"
-    private const val CURRENT_CACHE_VERSION = "2"
+internal class SharedPreferencesStorage(context: Context) : Storage {
+    private val preferences: SharedPreferences =
+        context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    private val cacheTimeout: Long = if (context.isDebuggable()) 60L else 90000L // 25 hours
 
     private val gson =
         GsonBuilder()
@@ -248,19 +217,6 @@ internal object SharedPreferencesStorage : Storage {
             }
         }
 
-    fun updateCustomer(apphudUser: ApphudUser): Boolean {
-        var userIdChanged = false
-        this.apphudUser?.let {
-            if (it.userId != apphudUser.userId) {
-                userIdChanged = true
-            }
-        }
-        this.apphudUser = apphudUser
-        this.userId = apphudUser.userId
-
-        return userIdChanged
-    }
-
     fun clean() {
         lastRegistration = 0L
         apphudUser = null
@@ -295,10 +251,10 @@ internal object SharedPreferencesStorage : Storage {
     }
 
     override var cacheVersion: String?
-        get() = preferences.getString("APPHUD_CACHE_VERSION", null)
+        get() = preferences.getString(CACHE_VERSION_KEY, null)
         set(value) {
             preferences.edit {
-                putString("APPHUD_CACHE_VERSION", value)
+                putString(CACHE_VERSION_KEY, value)
             }
         }
 
@@ -374,5 +330,30 @@ internal object SharedPreferencesStorage : Storage {
         currentProperties[property.key] = property
         properties = currentProperties
         return true
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "apphud.storage"
+        private const val USER_ID_KEY = "user_id"
+        private const val DEVICE_ID_KEY = "device_id"
+        private const val DEVICE_IDENTIFIERS_KEY = "device_identifiers"
+        private const val APPHUD_USER_KEY = "apphud_user"
+        private const val NEED_RESTART_KEY = "need_restart"
+        private const val FACEBOOK_KEY = "facebook_data"
+        private const val FIREBASE_KEY = "firebase_id"
+        private const val APPSFLYER_KEY = "appsflyer_data"
+        private const val ADJUST_KEY = "adjust_data"
+        private const val GROUP_KEY = "product_groups"
+        private const val GROUP_TIMESTAMP_KEY = "product_groups_timestamp"
+        private const val PAYWALLS_KEY = "paywalls"
+        private const val PAYWALLS_TIMESTAMP_KEY = "paywalls_timestamp"
+        private const val PLACEMENTS_KEY = "placements"
+        private const val PLACEMENTS_TIMESTAMP_KEY = "placements_timestamp"
+        private const val SKU_KEY = "sku_details"
+        private const val SKU_TIMESTAMP_KEY = "sku_details_timestamp"
+        private const val LAST_REGISTRATION_KEY = "last_registration"
+        private const val PROPERTIES_KEY = "properties"
+        private const val CACHE_VERSION_KEY = "APPHUD_CACHE_VERSION"
+        private const val CURRENT_CACHE_VERSION = "1"
     }
 }

--- a/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
+++ b/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
@@ -30,14 +30,6 @@ internal class SharedPreferencesStorage(context: Context) : Storage {
             .serializeNulls().create()
     private val parser: Parser = GsonParser(gson)
 
-    override var userId: String?
-        get() = preferences.getString(USER_ID_KEY, null)
-        set(value) {
-            preferences.edit {
-                putString(USER_ID_KEY, value)
-            }
-        }
-
     override var apphudUser: ApphudUser?
         get() {
             val source = preferences.getString(APPHUD_USER_KEY, null)

--- a/sdk/src/main/java/com/apphud/sdk/storage/Storage.kt
+++ b/sdk/src/main/java/com/apphud/sdk/storage/Storage.kt
@@ -11,7 +11,6 @@ import com.apphud.sdk.domain.FacebookInfo
 
 internal interface Storage {
     var lastRegistration: Long
-    var userId: String?
     var deviceId: String?
     var apphudUser: ApphudUser?
     var deviceIdentifiers: Array<String>


### PR DESCRIPTION
This commit refactors the SDK's user management by:
- Introducing `UserRepository` to handle `ApphudUser` state and persistence.
- Migrating `ApphudInternal` to delegate user operations to `UserRepository`.
- Adding `UpdateCustomerUseCase` for customer data updates.
- Converting `SharedPreferencesStorage` to a class for better dependency injection.
- Updating the demo app's `Apphud.start` call with new parameters.