### PR TITLE
FixApphudInternal.notifyLoadingCompleted: Fix thread-safety issues in…

### DIFF
--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
@@ -108,7 +108,7 @@ internal fun ApphudInternal.disableFallback() {
     ApphudLog.log("Fallback: DISABLED")
     coroutineScope.launch(errorHandler) {
         // if fallback raised on start, there no product groups, so reload products and details
-        if (productGroups.isEmpty()) {
+        if (productGroups.get().isEmpty()) {
             ApphudLog.log("Fallback: reload products")
             loadProducts()
         }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
@@ -105,7 +105,7 @@ internal suspend fun ApphudInternal.syncPurchases(
             refreshEntitlements(true)
             val user = currentUser
             return if (user != null) {
-                ApphudPurchasesRestoreResult.Success(user.subscriptions, user.purchases)
+                ApphudPurchasesRestoreResult.Success(user.subscriptions.toList(), user.purchases.toList())
             } else {
                 ApphudPurchasesRestoreResult.Error(ApphudError("User not found."))
             }
@@ -152,7 +152,7 @@ internal suspend fun ApphudInternal.syncPurchases(
                 }
                 val user = currentUser
                 return if (user != null) {
-                    ApphudPurchasesRestoreResult.Success(user.subscriptions, user.purchases)
+                    ApphudPurchasesRestoreResult.Success(user.subscriptions.toList(), user.purchases.toList())
                 } else {
                     ApphudPurchasesRestoreResult.Error(ApphudError("User not found."))
                 }
@@ -220,7 +220,7 @@ internal suspend fun ApphudInternal.sendPurchasesToApphud(
                 notifyLoadingCompleted(customer)
             }
 
-            ApphudPurchasesRestoreResult.Success(customer.subscriptions, customer.purchases)
+            ApphudPurchasesRestoreResult.Success(customer.subscriptions.toList(), customer.purchases.toList())
         },
         onFailure = { error ->
             ApphudPurchasesRestoreResult.Error(error.toApphudError())


### PR DESCRIPTION
Replace standard mutable collections with thread-safe alternatives to prevent race conditions and crashes in production.

Changes to collection types:
1. observedOrders: mutableList -> ConcurrentHashMap.newKeySet()
   - Fixes check-then-act race condition where multiple threads could process same order
   - Changes logic to use atomic add() that returns boolean
   - Performance improvement: O(1) instead of O(n) for contains/add operations
   - Correct data structure for unique order ID tracking

2. productDetails: mutableList -> CopyOnWriteArrayList
   - Thread-safe for concurrent reads without synchronization
   - Removes 3 synchronized blocks (lines 397, 1271, 1489 in old code)

3. prevPurchases: mutableSet -> CopyOnWriteArraySet
   - Consistent with other CopyOnWrite collections
   - Safe concurrent iteration and modification

4. productGroups: mutableList -> AtomicReference<List<ApphudGroup>>
   - Fixes critical issue where purchase flow could read empty list during update
   - Old pattern (clear + addAll) left list temporarily empty between operations
   - New pattern uses atomic set() ensuring readers always see complete list
   - Updated 9 access points across 4 files to use get()/set()

5. pendingUserProperties: mutableMap -> ConcurrentHashMap
   - Removes 3 synchronized blocks (lines 857, 883, 903)
   - Simplifies code with direct assignment instead of synchronized blocks

6. offeringsPreparedCallbacks: mutableList -> CopyOnWriteArrayList
   - Prevents ConcurrentModificationException when iterating callbacks

Additional safety improvements:
- Added defensive copying with toList() when passing collections to external listeners
- Prevents external modification of internal state
- Applied to: productDetails, paywalls, placements, user subscriptions/purchases (10 locations)

Files modified:
- ApphudInternal.kt: Main collection type changes and synchronized block removal
- ApphudInternal+Products.kt: loadedDetails thread-safety fixes
- ApphudInternal+Purchases.kt: observedOrders atomic logic, productGroups reads
- ApphudInternal+RestorePurchases.kt: Defensive copying for restore results
- ApphudInternal+Fallback.kt: productGroups access update

All changes maintain thread-safety without explicit locks, simplifying code while preventing production crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)