### PR TITLE
Remove_placements: Remove paywalls field from ApphudUser

### DIFF
--- a/demo/src/main/java/com/apphud/sampleapp/ui/utils/ApphudSdkManager.kt
+++ b/demo/src/main/java/com/apphud/sampleapp/ui/utils/ApphudSdkManager.kt
@@ -17,7 +17,6 @@ import com.apphud.sdk.ApphudPurchasesRestoreResult
 import com.apphud.sdk.ApphudUserPropertyKey
 import com.apphud.sdk.ApphudUtils
 import com.apphud.sdk.domain.ApphudNonRenewingPurchase
-import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudProduct
 import com.apphud.sdk.domain.ApphudSubscription
@@ -72,11 +71,6 @@ object ApphudSdkManager {
 
         override fun userDidLoad(user: ApphudUser) {
             Log.d("ColorGenerator", "userDidLoad(): ${user.userId}")
-            notifyAboutProducts()
-        }
-
-        override fun paywallsDidFullyLoad(paywalls: List<ApphudPaywall>) {
-            Log.d("ColorGenerator", "paywallsDidFullyLoad()")
             notifyAboutProducts()
         }
 

--- a/demo_old/src/main/java/com/apphud/demo/ui/customer/CustomerFragment.kt
+++ b/demo_old/src/main/java/com/apphud/demo/ui/customer/CustomerFragment.kt
@@ -20,8 +20,6 @@ import com.apphud.demo.databinding.FragmentCustomerBinding
 import com.apphud.sdk.Apphud
 import com.apphud.sdk.ApphudListener
 import com.apphud.sdk.domain.ApphudNonRenewingPurchase
-import com.apphud.sdk.domain.ApphudPaywall
-
 import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudSubscription
 import com.apphud.sdk.domain.ApphudUser
@@ -107,11 +105,6 @@ class CustomerFragment : Fragment() {
                 override fun userDidLoad(user: ApphudUser) {
                     Log.d("ApphudDemo", "userDidLoad(): ${user.userId}")
                     // TODO handle user registered event
-                    updateData()
-                }
-
-                override fun paywallsDidFullyLoad(paywalls: List<ApphudPaywall>) {
-                    Log.d("ApphudDemo", "paywallsDidFullyLoad()")
                     updateData()
                 }
 

--- a/demo_old/src/main/java/com/apphud/demo/ui/customer/PaywallsViewModel.kt
+++ b/demo_old/src/main/java/com/apphud/demo/ui/customer/PaywallsViewModel.kt
@@ -24,7 +24,7 @@ class PaywallsViewModel : ViewModel() {
                 items.add(AdapterItem(null, it))
             }
         } else {
-            val list = Apphud.rawPaywalls()
+            val list = Apphud.rawPlacements().mapNotNull { it.paywall }
             items.clear()
             val sortedPaywalls = list.sortedBy { it.name ?: "" }
             sortedPaywalls.forEach {

--- a/demo_old/src/main/java/com/apphud/demo/ui/products/ProductsFragment.kt
+++ b/demo_old/src/main/java/com/apphud/demo/ui/products/ProductsFragment.kt
@@ -127,7 +127,7 @@ class ProductsFragment : Fragment() {
             if (placementId != null) {
                 Apphud.placements().firstOrNull { it.identifier == placementId }?.paywall
             } else {
-                Apphud.rawPaywalls().firstOrNull { it.identifier == paywallId }
+                Apphud.rawPlacements().mapNotNull { it.paywall }.firstOrNull { it.identifier == paywallId }
             }
         return paywall
     }

--- a/sdk/src/main/java/com/apphud/sdk/Apphud.kt
+++ b/sdk/src/main/java/com/apphud/sdk/Apphud.kt
@@ -278,19 +278,6 @@ object Apphud {
      */
     fun rawPlacements(): List<ApphudPlacement> = ServiceLocator.instance.userRepository.getCurrentUser()?.placements.orEmpty()
 
-    /** Returns:
-     * List<ApphudPaywall>: A list of paywalls, potentially altered based
-     * on the user's involvement in A/B testing, if any.
-     *
-     * __Note__: This function doesn't suspend until inner `ProductDetails`
-     * are loaded from Google Play. That means paywalls may or may not have
-     * inner Google Play products at the time you call this function.
-     *
-     * To get paywalls with awaiting for inner Google Play products, use
-     * Apphud.paywalls() or Apphud.paywallsDidLoadCallback(...) functions.
-     */
-    fun rawPaywalls(): List<ApphudPaywall> = ServiceLocator.instance.userRepository.getCurrentUser()?.paywalls.orEmpty()
-
     /**
      * Disables automatic paywall and placement requests during the SDK's initial setup.
      * Developers must explicitly call `fetchPlacements` or `placements()` methods
@@ -313,49 +300,6 @@ object Apphud {
     }
 
     /**
-     * Returns the paywalls from Product Hub > Paywalls, potentially altered
-     * based on the user's involvement in A/B testing, if applicable.
-     * __Note:__ Method waits until the inner `ProductDetails` are loaded from Google Play.
-     *
-     * This is equivalent to `suspend fun paywalls()` method.
-     *
-     * Each paywall contains an array of `ApphudProduct` objects that
-     * can be used for purchases.
-     * `ApphudProduct` is Apphud's wrapper around `ProductDetails`.
-     *
-     * If you want to obtain paywalls without waiting for `ProductDetails` from
-     * Google Play, you can use `rawPaywalls()` method.
-     *
-     * __IMPORTANT:__ The callback may return both paywalls and an error simultaneously.
-     * If there is an issue with Google Billing and inner product details could not be fetched,
-     * an error will be returned along with the raw paywalls array.
-     * This allows for handling situations where partial data is available.
-     *
-     * @param preferredTimeout The approximate duration, in seconds, after which the SDK will cease
-     * retry attempts to Apphud backend in case of failures and return an error.
-     * The default and minimum value for this parameter is 10.0 seconds.
-     * This parameter doesn't affect fetching products from Google Play.
-     * @param callback The callback function that is invoked with the list of `ApphudPaywall` objects.
-     * Second parameter in callback represents optional error, which may be
-     * on Google (BillingClient issue) or Apphud side.
-     */
-    @Deprecated(
-        "Deprecated in favor of Placements",
-        ReplaceWith("this.placementsDidLoadCallback(callback)"),
-    )
-    fun paywallsDidLoadCallback(
-        preferredTimeout: Double = APPHUD_DEFAULT_MAX_TIMEOUT,
-        callback: (List<ApphudPaywall>, ApphudError?) -> Unit,
-    ) {
-        ApphudInternal.performWhenOfferingsPrepared(preferredTimeout = preferredTimeout) {
-            callback(
-                ServiceLocator.instance.userRepository.getCurrentUser()?.paywalls.orEmpty(),
-                it
-            )
-        }
-    }
-
-    /**
      * Call this method when your paywall screen is displayed to the user.
      * This is required for A/B testing analysis.
      *
@@ -363,16 +307,6 @@ object Apphud {
      */
     fun paywallShown(paywall: ApphudPaywall) {
         ApphudInternal.paywallShown(paywall)
-    }
-
-    /**
-     * Call this method when your paywall screen is dismissed without a purchase.
-     * This is required for A/B testing analysis.
-     *
-     * @param paywall The `ApphudPaywall` object representing the paywall that was closed.
-     */
-    fun paywallClosed(paywall: ApphudPaywall) {
-        ApphudInternal.paywallClosed(paywall)
     }
 
     /**
@@ -434,7 +368,7 @@ object Apphud {
      * Returns an array of `ProductDetails` objects, whose identifiers you added in Apphud > Product Hub > Products.
      * Note that this method will return empty array if products are not yet fetched.
      * To get notified when `products` are ready to use, implement `ApphudListener`'s
-     * `apphudFetchProductsDetails` or `paywallsDidFullyLoad` methods, or use `productsFetchCallback`.
+     * `apphudFetchProductsDetails` or `placementsDidFullyLoad` methods, or use `productsFetchCallback`.
      * When any of these methods is called, it indicates that `ProductDetails` are loaded and
      * the `products` method is ready to use.
      * It is recommended not to use this method directly, but to use `paywalls()` instead.

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
@@ -2,6 +2,7 @@ package com.apphud.sdk
 
 import android.content.Context
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.domain.FallbackJsonObject
 import com.apphud.sdk.internal.util.runCatchingCancellable
@@ -25,8 +26,7 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
     try {
         if (userRepository.getCurrentUser() == null) {
             val temporaryUser = ApphudUser(
-                userRepository.getUserId() ?: UUID.randomUUID().toString(), "", "", listOf(), listOf(), listOf(),
-                listOf(), true,
+                userRepository.getUserId() ?: UUID.randomUUID().toString(), "", "", listOf(), listOf(), listOf(), true,
             )
             userRepository.setCurrentUser(temporaryUser)
             ApphudLog.log("Fallback: user created: ${userRepository.getUserId()}")
@@ -34,7 +34,11 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
 
         processedFallbackData = true
 
-        var ids = (userRepository.getCurrentUser()?.paywalls.orEmpty()).map { it.products?.map { it.productId } ?: listOf() }.flatten()
+        var ids = userRepository.getCurrentUser()
+            ?.placements
+            ?.flatMap { it.paywall?.products.orEmpty() }
+            ?.map { it.productId }
+            .orEmpty()
         if (ids.isEmpty()) {
             val jsonFileString = getJsonDataFromAsset(context, "apphud_paywalls_fallback.json")
             val gson = Gson()
@@ -43,14 +47,14 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
             val paywallToParse = paywallsMapperLegacy.map(fallbackJson.data.results)
             ids = paywallToParse.map { it.products?.map { it.productId } ?: listOf() }.flatten()
 
+            val placements = paywallToParse.map { ApphudPlacement.createCustom(it.identifier, it) }
             val fallbackUser = ApphudUser(
                 userId = userRepository.getUserId() ?: UUID.randomUUID().toString(),
                 currencyCode = "",
                 countryCode = "",
                 subscriptions = listOf(),
                 purchases = listOf(),
-                paywalls = paywallToParse,
-                placements = listOf(),
+                placements = placements,
                 isTemporary = true
             )
             userRepository.setCurrentUser(fallbackUser)
@@ -85,7 +89,7 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
                     fromFallback = true,
                     fromCache = true
                 )
-                callback(user?.paywalls.orEmpty(), error)
+                callback(user?.placements?.mapNotNull { it.paywall }.orEmpty(), error)
             }
         }
     } catch (ex: Exception) {

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Products.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Products.kt
@@ -4,7 +4,6 @@ import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.ProductDetails
 import com.apphud.sdk.domain.ApphudGroup
-import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.internal.data.ProductLoadingState
 import com.apphud.sdk.internal.util.runCatchingCancellable
@@ -97,9 +96,8 @@ internal suspend fun retryProductsLoad() {
 
 internal suspend fun ApphudInternal.fetchProducts(): Int {
     val user = userRepository.getCurrentUser()
-    val userPaywalls = user?.paywalls.orEmpty()
     val userPlacements = user?.placements.orEmpty()
-    if (userPlacements.isEmpty() && userPaywalls.isEmpty()) {
+    if (userPlacements.isEmpty()) {
         if (user == null) {
             ApphudLog.log("Awaiting for user registration before proceeding to products load")
             awaitUserRegistration()
@@ -110,7 +108,6 @@ internal suspend fun ApphudInternal.fetchProducts(): Int {
     val refreshedUser = userRepository.getCurrentUser()
     val ids = allAvailableProductIds(
         getPermissionGroups(),
-        refreshedUser?.paywalls.orEmpty(),
         refreshedUser?.placements.orEmpty()
     )
 
@@ -119,26 +116,12 @@ internal suspend fun ApphudInternal.fetchProducts(): Int {
 
 private fun allAvailableProductIds(
     groups: List<ApphudGroup>,
-    paywalls: List<ApphudPaywall>,
     placements: List<ApphudPlacement>,
 ): List<String> {
-    val ids = paywalls.map { p -> p.products?.map { it.productId } ?: listOf() }.flatten().toMutableList()
-    val idsGroups = groups.map { it -> it.products?.map { it.productId } ?: listOf() }.flatten()
-    val idsFromPlacements =
-        placements.map { pl -> pl.paywall?.products?.map { it.productId } ?: listOf() }.flatten().toMutableList()
-
-    idsGroups.forEach {
-        if (!ids.contains(it)) {
-            ids.add(it)
-        }
-    }
-    idsFromPlacements.forEach {
-        if (!ids.contains(it)) {
-            ids.add(it)
-        }
-    }
-
-    return ids.toSet().toList()
+    return (
+        placements.flatMap { it.paywall?.products.orEmpty() }.map { it.productId } +
+        groups.flatMap { it.products.orEmpty() }.map { it.productId }
+    ).distinct()
 }
 
 internal suspend fun ApphudInternal.fetchDetails(

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Purchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Purchases.kt
@@ -18,6 +18,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private fun ApphudInternal.findPaywallScreenId(paywallId: String?): String? =
+    userRepository.getCurrentUser()?.placements
+        ?.firstNotNullOfOrNull { placement -> placement.paywall?.takeIf { it.id == paywallId } }
+        ?.screen?.id
+
 internal fun ApphudInternal.purchase(
     activity: Activity,
     apphudProduct: ApphudProduct?,
@@ -158,7 +163,7 @@ private fun ApphudInternal.purchaseInternal(
             ApphudLog.logE("OfferToken not set. You are required to pass offer token in Apphud.purchase method when purchasing subscription. Passing first offerToken as a fallback.")
         }
 
-        val currentPaywallScreenId = if (fromScreen) { userRepository.getCurrentUser()?.paywalls?.firstOrNull { it.id == apphudProduct.paywallId }?.screen?.id } else null
+        val currentPaywallScreenId = if (fromScreen) findPaywallScreenId(apphudProduct.paywallId) else null
 
         paywallCheckoutInitiated(apphudProduct.paywallId, apphudProduct.placementId, apphudProduct.productId, currentPaywallScreenId)
         purchasingProduct = apphudProduct
@@ -443,7 +448,7 @@ private suspend fun ApphudInternal.sendCheckToApphud(
     fromScreen: Boolean,
     callback: ((ApphudPurchaseResult) -> Unit)?,
 ) {
-    val currentPaywallScreenId = if (fromScreen) { userRepository.getCurrentUser()?.paywalls?.firstOrNull { it.id == paywallId }?.screen?.id } else null
+    val currentPaywallScreenId = if (fromScreen) findPaywallScreenId(paywallId) else null
 
     val localCurrentUser = userRepository.getCurrentUser()
     when {

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
@@ -194,15 +194,15 @@ private fun ApphudInternal.findJustPurchasedProduct(
 ): ApphudProduct? {
     try {
         val user = userRepository.getCurrentUser()
-        val userPaywalls = user?.paywalls.orEmpty()
         val userPlacements = user?.placements.orEmpty()
 
-        val targetPaywall =
-            if (placementIdentifier != null) {
-                userPlacements.firstOrNull { it.identifier == placementIdentifier }?.paywall
-            } else {
-                userPaywalls.firstOrNull { it.identifier == paywallIdentifier }
-            }
+        val targetPaywall = when {
+            placementIdentifier != null ->
+                userPlacements.firstOrNull { placement -> placement.identifier == placementIdentifier }?.paywall
+            paywallIdentifier != null ->
+                userPlacements.firstNotNullOfOrNull { placement -> placement.paywall?.takeIf { paywall -> paywall.identifier == paywallIdentifier } }
+            else -> null
+        }
 
         productDetails?.let { details ->
             return targetPaywall?.products?.find { it.productDetails?.productId == details.productId }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
@@ -14,6 +14,7 @@ import com.apphud.sdk.body.UserPropertiesBody
 import com.apphud.sdk.domain.ApphudGroup
 import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPaywallScreenShowResult
+import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudProduct
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.domain.PaywallEvent
@@ -224,8 +225,8 @@ internal object ApphudInternal {
             ApphudLog.logI("Ignoring local paywalls cache")
         }
 
-        val cachedPaywalls =
-            if (ignoreCache || !isValid || observerMode) null else userRepository.getCurrentUser()?.paywalls
+        val cachedPlacements =
+            if (ignoreCache || !isValid || observerMode) null else userRepository.getCurrentUser()?.placements
 
         sdkLaunchedAt = System.currentTimeMillis()
 
@@ -239,7 +240,7 @@ internal object ApphudInternal {
 
         forceNotifyAllLoaded()
 
-        val needRegistration = needRegistration(credentialsChanged, cachedPaywalls)
+        val needRegistration = needRegistration(credentialsChanged, cachedPlacements)
 
         ApphudLog.log("Need to register user: $needRegistration")
 
@@ -267,11 +268,11 @@ internal object ApphudInternal {
     //region === Registration ===
     private fun needRegistration(
         credentialsChanged: Boolean,
-        cachedPaywalls: List<ApphudPaywall>?,
+        cachedPlacements: List<ApphudPlacement>?,
     ): Boolean {
         val cachedUser = userRepository.getCurrentUser()
         return credentialsChanged ||
-            cachedPaywalls == null ||
+            cachedPlacements == null ||
             cachedUser == null ||
             cachedUser.isTemporary == true ||
             cachedUser.hasPurchases() ||
@@ -382,7 +383,7 @@ internal object ApphudInternal {
     private fun isDataReady(): Boolean {
         val user = userRepository.getCurrentUser()
         return user != null &&
-            user.paywalls.isNotEmpty() &&
+            user.placements.isNotEmpty() &&
             productDetails.isNotEmpty() &&
             !isRegisteringUser
     }
@@ -396,7 +397,7 @@ internal object ApphudInternal {
         hasRespondedToPaywallsRequest || customerError != null
 
     private fun hasDataLoadFailed(customerError: ApphudError?) =
-        (customerError != null && (userRepository.getCurrentUser()?.paywalls?.isEmpty() != false)) || isProductsLoadFailed()
+        (customerError != null && (userRepository.getCurrentUser()?.placements?.isEmpty() != false)) || isProductsLoadFailed()
 
     private fun isProductsLoadFailed(): Boolean {
         val state = productRepository.state.value
@@ -406,7 +407,6 @@ internal object ApphudInternal {
     private fun handleSuccessfulLoad() {
         val user = userRepository.getCurrentUser()
         if (!notifiedAboutPaywallsDidFullyLoaded) {
-            apphudListener?.paywallsDidFullyLoad(user?.paywalls?.toList().orEmpty())
             apphudListener?.placementsDidFullyLoad(user?.placements?.toList().orEmpty())
 
             notifiedAboutPaywallsDidFullyLoaded = true
@@ -456,7 +456,7 @@ internal object ApphudInternal {
         val productsState = productRepository.state.value
         val productsResponseCode =
             if (productsState is ProductLoadingState.Failed) productsState.responseCode else BillingClient.BillingResponseCode.OK
-        ApphudLog.log("Not yet ready for callbacks invoke: isRegisteringUser: $isRegisteringUser, currentUserExist: ${user != null}, latestCustomerError: $latestCustomerLoadError, paywallsEmpty: ${user?.paywalls?.isEmpty() != false}, productsResponseCode = $productsResponseCode, productsStatus: $productsState, productDetailsEmpty: ${productDetails.isEmpty()}, deferred: $deferPlacements, hasRespondedToPaywallsRequest=$hasRespondedToPaywallsRequest")
+        ApphudLog.log("Not yet ready for callbacks invoke: isRegisteringUser: $isRegisteringUser, currentUserExist: ${user != null}, latestCustomerError: $latestCustomerLoadError, placementsEmpty: ${user?.placements?.isEmpty() != false}, productsResponseCode = $productsResponseCode, productsStatus: $productsState, productDetailsEmpty: ${productDetails.isEmpty()}, deferred: $deferPlacements, hasRespondedToPaywallsRequest=$hasRespondedToPaywallsRequest")
     }
 
     private fun trackAnalytics(success: Boolean) {
@@ -501,7 +501,7 @@ internal object ApphudInternal {
 
     private fun handleCustomerError(customerError: ApphudError) {
         val user = userRepository.getCurrentUser()
-        if (customerError.isRetryable() && (user == null || productDetails.isEmpty() || ((user.paywalls.isEmpty()) && !observerMode)) && isActive && !refreshUserPending && userLoadRetryCount < APPHUD_INFINITE_RETRIES) {
+        if (customerError.isRetryable() && (user == null || productDetails.isEmpty() || ((user.placements.isEmpty()) && !observerMode)) && isActive && !refreshUserPending && userLoadRetryCount < APPHUD_INFINITE_RETRIES) {
             refreshUserPending = true
             coroutineScope.launch {
                 val delay = 500L * userLoadRetryCount
@@ -696,7 +696,7 @@ internal object ApphudInternal {
         if (isRegisteringUser) {
             // already loading
             isLoading = true
-        } else if (user == null || fallbackMode || user.isTemporary == true || ((user.paywalls.isEmpty()) && !observerMode) || latestCustomerLoadError != null) {
+        } else if (user == null || fallbackMode || user.isTemporary == true || ((user.placements.isEmpty()) && !observerMode) || latestCustomerLoadError != null) {
             ApphudLog.logI("Refreshing User")
             didRegisterCustomerAtThisLaunch = false
             refreshEntitlements(true)
@@ -883,14 +883,6 @@ internal object ApphudInternal {
         }
     }
 
-    fun paywallClosed(paywall: ApphudPaywall) {
-        coroutineScope.launch {
-            runCatchingCancellable { paywallClosedSuspend(paywall) }
-                .onFailure { error -> ApphudLog.logI(error.message ?: "Unknown error") }
-        }
-    }
-
-
     suspend fun showPaywallScreen(
         context: Context,
         paywall: ApphudPaywall,
@@ -1032,11 +1024,6 @@ internal object ApphudInternal {
     private suspend fun paywallShownSuspend(paywall: ApphudPaywall) {
         awaitUserRegistration()
         RequestManager.paywallShown(paywall)
-    }
-
-    private suspend fun paywallClosedSuspend(paywall: ApphudPaywall) {
-        awaitUserRegistration()
-        RequestManager.paywallClosed(paywall)
     }
 
     private suspend fun paywallCheckoutInitiatedSuspend(
@@ -1237,16 +1224,7 @@ internal object ApphudInternal {
 
     private fun updatePaywallsAndPlacements() {
         val user = userRepository.getCurrentUser()
-        val userPaywalls = user?.paywalls.orEmpty()
         val userPlacements = user?.placements.orEmpty()
-
-        userPaywalls.forEach { paywall ->
-            paywall.products?.forEach { product ->
-                product.paywallId = paywall.id
-                product.paywallIdentifier = paywall.identifier
-                product.productDetails = getProductDetailsByProductId(product.productId)
-            }
-        }
 
         userPlacements.forEach { placement ->
             val paywall = placement.paywall ?: return@forEach
@@ -1283,7 +1261,7 @@ internal object ApphudInternal {
         }
 
         hasRespondedToPaywallsRequest =
-            hasRespondedToPaywallsRequest || user.paywalls.isNotEmpty() || user.placements.isNotEmpty() || observerMode
+            hasRespondedToPaywallsRequest || user.placements.isNotEmpty() || observerMode
 
         // Disable fallback mode if needed
         if (user.isTemporary != true && fallbackMode) {

--- a/sdk/src/main/java/com/apphud/sdk/ApphudListener.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudListener.kt
@@ -3,7 +3,6 @@ package com.apphud.sdk
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.apphud.sdk.domain.ApphudNonRenewingPurchase
-import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudSubscription
 import com.apphud.sdk.domain.ApphudUser
@@ -48,11 +47,6 @@ interface ApphudListener {
      * since it may change at runtime.
      */
     fun userDidLoad(user: ApphudUser)
-
-    /**
-    Called when paywalls are fully loaded with their inner ProductDetails.
-     */
-    fun paywallsDidFullyLoad(paywalls: List<ApphudPaywall>)
 
     /**
      * Called when placements are fully loaded with their ApphudPaywalls and

--- a/sdk/src/main/java/com/apphud/sdk/body/RegistrationBody.kt
+++ b/sdk/src/main/java/com/apphud/sdk/body/RegistrationBody.kt
@@ -31,8 +31,6 @@ internal data class RegistrationBody(
     val isSandbox: Boolean,
     @SerializedName("is_new")
     val isNew: Boolean,
-    @SerializedName("need_paywalls")
-    val needPaywalls: Boolean,
     @SerializedName("need_placements")
     val needPlacements: Boolean,
     @SerializedName("first_seen")

--- a/sdk/src/main/java/com/apphud/sdk/domain/ApphudUser.kt
+++ b/sdk/src/main/java/com/apphud/sdk/domain/ApphudUser.kt
@@ -1,6 +1,5 @@
 package com.apphud.sdk.domain
 
-import com.apphud.sdk.ApphudInternal
 import com.apphud.sdk.UserId
 
 data class ApphudUser(
@@ -32,39 +31,12 @@ data class ApphudUser(
     var purchases: List<ApphudNonRenewingPurchase>,
 
     /**
-     * There properties are for internal usage, to get paywalls and placements
-     * use paywalls() and placements() functions below
+     * There properties are for internal usage, to get placements
+     * use placements() function below
      */
-    internal val paywalls: List<ApphudPaywall>,
     internal val placements: List<ApphudPlacement>,
     internal val isTemporary: Boolean?,
 ) {
-    /** Returns:
-     * List<ApphudPlacement>: A list of placements, potentially altered based
-     * on the user's involvement in A/B testing, if any.
-     *
-     * __Note__: This function doesn't suspend until inner `ProductDetails`
-     * are loaded from Google Play. That means placements may or may not have
-     * inner Google Play products at the time you call this function.
-     *
-     * To get placements with awaiting for inner Google Play products, use
-     * Apphud.placements() or Apphud.placementsDidLoadCallback(...) functions.
-     */
-    fun rawPlacements(): List<ApphudPlacement> = ApphudInternal.userRepository.getCurrentUser()?.placements.orEmpty()
-
-    /** Returns:
-     * List<ApphudPaywall>: A list of paywalls, potentially altered based
-     * on the user's involvement in A/B testing, if any.
-     *
-     * __Note__: This function doesn't suspend until inner `ProductDetails`
-     * are loaded from Google Play. That means paywalls may or may not have
-     * inner Google Play products at the time you call this function.
-     *
-     * To get paywalls with awaiting for inner Google Play products, use
-     * Apphud.paywalls() or Apphud.paywallsDidLoadCallback(...) functions.
-     */
-    fun rawPaywalls(): List<ApphudPaywall> = ApphudInternal.userRepository.getCurrentUser()?.paywalls.orEmpty()
-
     /**
      * Returns true if user has any subscriptions or non-renewing purchases.
      */

--- a/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
@@ -67,7 +67,7 @@ internal class ServiceLocator(
     private val placementsMapper = PlacementsMapper(paywallsMapper)
     private val subscriptionMapper = SubscriptionMapper()
     private val customerMapper =
-        CustomerMapper(subscriptionMapper, paywallsMapper, placementsMapper)
+        CustomerMapper(subscriptionMapper, placementsMapper)
 
     val userDataSource: UserDataSource = UserDataSource(storage)
 

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/UserRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/UserRepository.kt
@@ -37,15 +37,12 @@ internal class UserRepository(
     fun setCurrentUser(user: ApphudUser): Boolean {
         val userIdChanged = currentUser?.userId != user.userId
 
-        // Preserve paywalls/placements if server returned empty ones.
+        // Merges placements if server returned empty ones.
         // This happens when /subscriptions endpoint is called (purchase verification)
-        // which doesn't return paywalls, only subscription data.
+        // which doesn't return placements, only subscription data.
         val existing = currentUser
-        val mergedUser = if (user.paywalls.isEmpty() && existing?.paywalls?.isNotEmpty() == true) {
-            user.copy(
-                paywalls = existing.paywalls,
-                placements = existing.placements
-            )
+        val mergedUser = if (user.placements.isEmpty() && existing?.placements?.isNotEmpty() == true) {
+            user.copy(placements = existing.placements)
         } else {
             user
         }

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/dto/CustomerDto.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/dto/CustomerDto.kt
@@ -7,6 +7,5 @@ internal data class CustomerDto(
     val userId: String,
     val subscriptions: List<SubscriptionDto>,
     val currency: CurrencyDto?,
-    val paywalls: List<ApphudPaywallDto>?,
     val placements: List<ApphudPlacementDto>?,
 )

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/local/PaywallRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/local/PaywallRepository.kt
@@ -18,7 +18,8 @@ internal class PaywallRepository {
         runCatching {
             ApphudLog.log("[PaywallRepository] Searching for paywall with ID: $paywallId")
 
-            val paywall = ApphudInternal.userRepository.getCurrentUser()?.paywalls?.firstOrNull { it.id == paywallId }
+            val paywall = ApphudInternal.userRepository.getCurrentUser()
+                ?.placements?.firstNotNullOfOrNull { it.paywall?.takeIf { pw -> pw.id == paywallId } }
 
             if (paywall != null) {
                 ApphudLog.log("[PaywallRepository] Found paywall: ${paywall.name} (${paywall.identifier})")

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/CustomerMapper.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/CustomerMapper.kt
@@ -6,7 +6,6 @@ import com.apphud.sdk.domain.ApphudUser
 
 internal class CustomerMapper(
     private val mapper: SubscriptionMapper,
-    private val paywallsMapper: PaywallsMapper,
     private var placementsMapper: PlacementsMapper,
 ) {
     fun map(customer: CustomerDto) =
@@ -24,12 +23,6 @@ internal class CustomerMapper(
                 .filter { it.kind == ApphudKind.NONRENEWABLE.source }
                 .mapNotNull { mapper.mapNonRenewable(it) }
                 .sortedByDescending { it.purchasedAt },
-            paywalls =
-            customer.paywalls?.let { paywallsList ->
-                paywallsList.map { paywallsMapper.map(it) }
-            } ?: run {
-                listOf()
-            },
             placements =
             customer.placements?.let { placementsList ->
                 placementsList.map { placementsMapper.map(it) }

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/PaywallsMapper.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/PaywallsMapper.kt
@@ -1,6 +1,5 @@
 package com.apphud.sdk.internal.data.mapper
 
-import android.util.Log
 import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPaywallScreen
 import com.apphud.sdk.domain.ApphudProduct

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RegistrationBodyFactory.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RegistrationBodyFactory.kt
@@ -10,7 +10,7 @@ internal class RegistrationBodyFactory(
 ) {
 
     fun create(
-        needPaywalls: Boolean,
+        needPlacements: Boolean,
         isNew: Boolean,
         userId: UserId? = null,
         email: String? = null,
@@ -32,8 +32,7 @@ internal class RegistrationBodyFactory(
             timeZone = registrationProvider.getTimeZone(),
             isSandbox = registrationProvider.isSandbox(),
             isNew = isNew,
-            needPaywalls = needPaywalls,
-            needPlacements = needPaywalls,
+            needPlacements = needPlacements,
             firstSeen = registrationProvider.getFirstSeen(),
             sdkLaunchedAt = registrationProvider.getSdkLaunchedAt(),
             requestTime = registrationProvider.getRequestTime(),

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RemoteRepository.kt
@@ -45,14 +45,14 @@ internal class RemoteRepository(
 ) {
 
     suspend fun getCustomers(
-        needPaywalls: Boolean,
+        needPlacements: Boolean,
         isNew: Boolean,
         userId: UserId? = null,
         email: String? = null,
     ): Result<ApphudUser> =
         runCatchingCancellable {
             val request =
-                buildPostRequest(urlProvider.customersUrl, registrationBodyFactory.create(needPaywalls, isNew, userId, email))
+                buildPostRequest(urlProvider.customersUrl, registrationBodyFactory.create(needPlacements, isNew, userId, email))
             executeForResponse<CustomerDto>(okHttpClient, gson, request)
         }
             .recoverCatchingCancellable { e ->

--- a/sdk/src/main/java/com/apphud/sdk/internal/domain/RegistrationUseCase.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/domain/RegistrationUseCase.kt
@@ -71,7 +71,7 @@ internal class RegistrationUseCase(
 
         val newUser = runCatchingCancellable {
             requestManager.registration(
-                needPaywalls = needPlacementsPaywalls,
+                needPlacements = needPlacementsPaywalls,
                 isNew = isNew,
                 forceRegistration = forceRegistration,
                 userId = userId,
@@ -98,17 +98,11 @@ internal class RegistrationUseCase(
     ): ApphudUser {
         if (cachedUser == null) return newUser
 
-        val shouldPreservePaywalls = newUser.paywalls.isEmpty() && cachedUser.paywalls.isNotEmpty()
         val shouldPreservePlacements = newUser.placements.isEmpty() && cachedUser.placements.isNotEmpty()
 
-        return if (shouldPreservePaywalls || shouldPreservePlacements) {
-            ApphudLog.log(
-                "Preserving cached paywalls/placements: " +
-                    "paywalls=${shouldPreservePaywalls}, placements=${shouldPreservePlacements}"
-            )
+        return if (shouldPreservePlacements) {
             newUser.copy(
-                paywalls = if (shouldPreservePaywalls) cachedUser.paywalls else newUser.paywalls,
-                placements = if (shouldPreservePlacements) cachedUser.placements else newUser.placements
+                placements = cachedUser.placements
             )
         } else {
             newUser

--- a/sdk/src/main/java/com/apphud/sdk/managers/RequestManager.kt
+++ b/sdk/src/main/java/com/apphud/sdk/managers/RequestManager.kt
@@ -67,7 +67,7 @@ internal object RequestManager {
     }
 
     suspend fun registration(
-        needPaywalls: Boolean,
+        needPlacements: Boolean,
         isNew: Boolean,
         forceRegistration: Boolean = false,
         userId: UserId? = null,
@@ -82,7 +82,7 @@ internal object RequestManager {
         return if (currentUserLocal == null || forceRegistration) {
             val repository = ServiceLocator.instance.remoteRepository
 
-            val getCustomersResult = repository.getCustomers(needPaywalls, isNew, userId, email)
+            val getCustomersResult = repository.getCustomers(needPlacements, isNew, userId, email)
 
             getCustomersResult
                 .getOrElse { t ->
@@ -119,7 +119,7 @@ internal object RequestManager {
         }
 
         if (currentUser == null) {
-            registration(needPaywalls = true, isNew = true)
+            registration(needPlacements = true, isNew = true)
         }
 
         val remoteRepository = ServiceLocator.instance.remoteRepository
@@ -139,7 +139,7 @@ internal object RequestManager {
         }
 
         if (currentUser == null) {
-            registration(needPaywalls = true, isNew = true)
+            registration(needPlacements = true, isNew = true)
         }
 
         val repository = ServiceLocator.instance.remoteRepository
@@ -159,7 +159,7 @@ internal object RequestManager {
             val repository = ServiceLocator.instance.remoteRepository
 
             if (currentUser == null) {
-                registration(needPaywalls = true, isNew = true)
+                registration(needPlacements = true, isNew = true)
             }
 
             repository.sendAttribution(attributionRequestBody).getOrThrow()
@@ -175,7 +175,7 @@ internal object RequestManager {
         }
 
         if (currentUser == null) {
-            registration(needPaywalls = true, isNew = true)
+            registration(needPlacements = true, isNew = true)
         }
 
         val userRemoteRepository = ServiceLocator.instance.userRemoteRepository
@@ -195,7 +195,7 @@ internal object RequestManager {
 
         return runCatchingCancellable {
             if (currentUser == null) {
-                registration(needPaywalls = true, isNew = true)
+                registration(needPlacements = true, isNew = true)
             }
 
             val repository = ServiceLocator.instance.remoteRepository
@@ -216,16 +216,6 @@ internal object RequestManager {
         trackPaywallEvent(
             makePaywallEventBody(
                 name = "paywall_shown",
-                paywallId = paywall.id,
-                placementId = paywall.placementId,
-            ),
-        )
-    }
-
-    suspend fun paywallClosed(paywall: ApphudPaywall) {
-        trackPaywallEvent(
-            makePaywallEventBody(
-                name = "paywall_closed",
                 paywallId = paywall.id,
                 placementId = paywall.placementId,
             ),
@@ -317,7 +307,7 @@ internal object RequestManager {
 
         runCatchingCancellable {
             if (currentUser == null) {
-                registration(needPaywalls = true, isNew = true)
+                registration(needPlacements = true, isNew = true)
             }
 
             val repository = ServiceLocator.instance.remoteRepository

--- a/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
+++ b/sdk/src/main/java/com/apphud/sdk/storage/SharedPreferencesStorage.kt
@@ -236,23 +236,19 @@ internal class SharedPreferencesStorage(
             return
         }
 
-        val legacyPaywalls = readLegacyPaywalls()
         val legacyPlacements = readLegacyPlacements()
 
-        if (legacyPaywalls.isNullOrEmpty() && legacyPlacements.isNullOrEmpty()) {
+        if (legacyPlacements.isNullOrEmpty()) {
             clearLegacyPaywallsCache()
             return
         }
 
-        val needMigration = currentUser.paywalls.isEmpty() && !legacyPaywalls.isNullOrEmpty()
+        val needMigration = currentUser.placements.isEmpty() && !legacyPlacements.isNullOrEmpty()
 
         if (needMigration) {
-            val migratedUser = currentUser.copy(
-                paywalls = legacyPaywalls,
-                placements = legacyPlacements ?: listOf()
-            )
+            val migratedUser = currentUser.copy(placements = legacyPlacements)
             apphudUser = migratedUser
-            ApphudLog.log("Migrated paywalls/placements to ApphudUser")
+            ApphudLog.log("Migrated placements to ApphudUser")
         }
 
         clearLegacyPaywallsCache()

--- a/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
@@ -117,7 +117,6 @@ class ApphudHasPremiumAccessTest {
             countryCode = "US",
             subscriptions = subscriptions,
             purchases = emptyList(),
-            paywalls = emptyList(),
             placements = emptyList(),
             isTemporary = false
         )
@@ -130,7 +129,6 @@ class ApphudHasPremiumAccessTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = purchases,
-            paywalls = emptyList(),
             placements = emptyList(),
             isTemporary = false
         )

--- a/sdk/src/test/java/com/apphud/sdk/internal/data/UserRepositoryTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/data/UserRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.apphud.sdk.internal.data
 
-import com.apphud.sdk.domain.ApphudPaywall
 import com.apphud.sdk.domain.ApphudPlacement
 import com.apphud.sdk.domain.ApphudUser
 import io.mockk.every
@@ -21,22 +20,7 @@ class UserRepositoryTest {
     private val mockUser2: ApphudUser = mockk(relaxed = true)
     private val temporaryUser: ApphudUser = mockk(relaxed = true)
 
-    private fun createTestPaywall(id: String = "paywall-1") = ApphudPaywall(
-        id = id,
-        name = "Test Paywall",
-        identifier = "test_paywall",
-        default = false,
-        json = null,
-        products = null,
-        screen = null,
-        experimentName = null,
-        variationName = null,
-        parentPaywallIdentifier = null,
-        placementIdentifier = null,
-        placementId = null
-    )
-
-    private fun createTestPlacement(id: String = "placement-1", paywall: ApphudPaywall? = null) = ApphudPlacement(
+    private fun createTestPlacement(id: String = "placement-1", paywall: com.apphud.sdk.domain.ApphudPaywall? = null) = ApphudPlacement(
         identifier = "test_placement",
         paywall = paywall,
         id = id
@@ -44,7 +28,6 @@ class UserRepositoryTest {
 
     private fun createTestUser(
         userId: String,
-        paywalls: List<ApphudPaywall> = emptyList(),
         placements: List<ApphudPlacement> = emptyList(),
         isTemporary: Boolean = false
     ) = ApphudUser(
@@ -53,7 +36,6 @@ class UserRepositoryTest {
         countryCode = null,
         subscriptions = emptyList(),
         purchases = emptyList(),
-        paywalls = paywalls,
         placements = placements,
         isTemporary = isTemporary
     )
@@ -155,91 +137,80 @@ class UserRepositoryTest {
     }
 
     @Test
-    fun `setCurrentUser should preserve paywalls when new user has empty paywalls`() {
-        val paywall = createTestPaywall()
-        val placement = createTestPlacement(paywall = paywall)
-        val userWithPaywalls = createTestUser(
+    fun `setCurrentUser should preserve placements when new user has empty placements`() {
+        val placement = createTestPlacement()
+        val userWithPlacements = createTestUser(
             userId = "user-1",
-            paywalls = listOf(paywall),
             placements = listOf(placement)
         )
-        val userWithEmptyPaywalls = createTestUser(
+        val userWithEmptyPlacements = createTestUser(
             userId = "user-1",
-            paywalls = emptyList(),
             placements = emptyList()
         )
 
-        repository.setCurrentUser(userWithPaywalls)
-        repository.setCurrentUser(userWithEmptyPaywalls)
+        repository.setCurrentUser(userWithPlacements)
+        repository.setCurrentUser(userWithEmptyPlacements)
         val result = repository.getCurrentUser()
 
-        assertEquals("Paywalls should be preserved", 1, result?.paywalls?.size)
         assertEquals("Placements should be preserved", 1, result?.placements?.size)
-        assertEquals("Paywall id should match", paywall.id, result?.paywalls?.first()?.id)
+        assertEquals("Placement id should match", placement.id, result?.placements?.first()?.id)
     }
 
     @Test
-    fun `setCurrentUser should replace paywalls when new user has non-empty paywalls`() {
-        val oldPaywall = createTestPaywall(id = "old-paywall")
-        val newPaywall = createTestPaywall(id = "new-paywall")
-        val userWithOldPaywalls = createTestUser(
+    fun `setCurrentUser should replace placements when new user has non-empty placements`() {
+        val oldPlacement = createTestPlacement(id = "old-placement")
+        val newPlacement = createTestPlacement(id = "new-placement")
+        val userWithOldPlacements = createTestUser(
             userId = "user-1",
-            paywalls = listOf(oldPaywall),
-            placements = emptyList()
+            placements = listOf(oldPlacement)
         )
-        val userWithNewPaywalls = createTestUser(
+        val userWithNewPlacements = createTestUser(
             userId = "user-1",
-            paywalls = listOf(newPaywall),
-            placements = emptyList()
+            placements = listOf(newPlacement)
         )
 
-        repository.setCurrentUser(userWithOldPaywalls)
-        repository.setCurrentUser(userWithNewPaywalls)
+        repository.setCurrentUser(userWithOldPlacements)
+        repository.setCurrentUser(userWithNewPlacements)
         val result = repository.getCurrentUser()
 
-        assertEquals("Should have 1 paywall", 1, result?.paywalls?.size)
-        assertEquals("Paywall should be replaced with new one", "new-paywall", result?.paywalls?.first()?.id)
+        assertEquals("Should have 1 placement", 1, result?.placements?.size)
+        assertEquals("Placement should be replaced with new one", "new-placement", result?.placements?.first()?.id)
     }
 
     @Test
-    fun `setCurrentUser should not preserve paywalls when current user has none`() {
-        val userWithEmptyPaywalls1 = createTestUser(
+    fun `setCurrentUser should not preserve placements when current user has none`() {
+        val userWithEmptyPlacements1 = createTestUser(
             userId = "user-1",
-            paywalls = emptyList(),
             placements = emptyList()
         )
-        val userWithEmptyPaywalls2 = createTestUser(
+        val userWithEmptyPlacements2 = createTestUser(
             userId = "user-1",
-            paywalls = emptyList(),
             placements = emptyList()
         )
 
-        repository.setCurrentUser(userWithEmptyPaywalls1)
-        repository.setCurrentUser(userWithEmptyPaywalls2)
+        repository.setCurrentUser(userWithEmptyPlacements1)
+        repository.setCurrentUser(userWithEmptyPlacements2)
         val result = repository.getCurrentUser()
 
-        assertTrue("Paywalls should remain empty", result?.paywalls?.isEmpty() == true)
+        assertTrue("Placements should remain empty", result?.placements?.isEmpty() == true)
     }
 
     @Test
     fun `setCurrentUser should save merged user to dataSource`() {
-        val paywall = createTestPaywall()
-        val placement = createTestPlacement(paywall = paywall)
-        val userWithPaywalls = createTestUser(
+        val placement = createTestPlacement()
+        val userWithPlacements = createTestUser(
             userId = "user-1",
-            paywalls = listOf(paywall),
             placements = listOf(placement)
         )
-        val userWithEmptyPaywalls = createTestUser(
+        val userWithEmptyPlacements = createTestUser(
             userId = "user-1",
-            paywalls = emptyList(),
             placements = emptyList()
         )
 
-        repository.setCurrentUser(userWithPaywalls)
-        repository.setCurrentUser(userWithEmptyPaywalls)
+        repository.setCurrentUser(userWithPlacements)
+        repository.setCurrentUser(userWithEmptyPlacements)
 
-        verify(exactly = 2) { dataSource.saveUser(match { it.paywalls.size == 1 }) }
+        verify(exactly = 2) { dataSource.saveUser(match { it.placements.size == 1 }) }
     }
 
     // region getUserId fallback chain

--- a/sdk/src/test/java/com/apphud/sdk/internal/data/remote/RemoteRepositoryTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/data/remote/RemoteRepositoryTest.kt
@@ -106,7 +106,7 @@ class RemoteRepositoryTest {
         mockHttpCall(createMockResponse(200, createSuccessResponse()))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -121,7 +121,7 @@ class RemoteRepositoryTest {
         mockHttpCall(createMockResponse(401, create401ErrorResponse()))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -145,7 +145,7 @@ class RemoteRepositoryTest {
         mockHttpCallWithException(java.net.SocketTimeoutException("timeout"))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -168,7 +168,7 @@ class RemoteRepositoryTest {
         mockHttpCall(createMockResponse(200, invalidJson))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -183,7 +183,7 @@ class RemoteRepositoryTest {
         mockHttpCall(createMockResponse(200, responseWithNullResults))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -203,7 +203,7 @@ class RemoteRepositoryTest {
         mockHttpCall(createMockResponse(500, "Internal Server Error"))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null
@@ -223,7 +223,7 @@ class RemoteRepositoryTest {
         mockHttpCallWithException(java.net.ConnectException("Connection refused"))
 
         val result = remoteRepository.getCustomers(
-            needPaywalls = true,
+            needPlacements = true,
             isNew = false,
             userId = null,
             email = null

--- a/sdk/src/test/java/com/apphud/sdk/internal/domain/DeviceIdentifiersInteractorTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/domain/DeviceIdentifiersInteractorTest.kt
@@ -22,7 +22,6 @@ class DeviceIdentifiersInteractorTest {
         countryCode = null,
         subscriptions = emptyList(),
         purchases = emptyList(),
-        paywalls = emptyList(),
         placements = emptyList(),
         isTemporary = false,
     )

--- a/sdk/src/test/java/com/apphud/sdk/internal/domain/RegistrationUseCaseTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/domain/RegistrationUseCaseTest.kt
@@ -80,7 +80,6 @@ class RegistrationUseCaseTest {
         val temporaryUser: ApphudUser = mockk {
             every { userId } returns "temp-user"
             every { isTemporary } returns true
-            every { paywalls } returns emptyList()
             every { placements } returns emptyList()
         }
         every { userRepository.getCurrentUser() } returns temporaryUser
@@ -211,7 +210,6 @@ class RegistrationUseCaseTest {
         val cachedUser: ApphudUser = mockk {
             every { userId } returns "cached-user"
             every { isTemporary } returns false
-            every { paywalls } returns emptyList()
             every { placements } returns emptyList()
         }
         every { userRepository.getCurrentUser() } returns cachedUser
@@ -326,7 +324,6 @@ class RegistrationUseCaseTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = listOf(cachedPaywall),
             placements = listOf(cachedPlacement),
             isTemporary = false
         )
@@ -337,7 +334,6 @@ class RegistrationUseCaseTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = emptyList(),
             placements = emptyList(),
             isTemporary = false
         )
@@ -352,58 +348,32 @@ class RegistrationUseCaseTest {
             forceRegistration = true
         )
 
-        assertEquals(1, result.paywalls.size)
         assertEquals(1, result.placements.size)
-        assertEquals("paywall-1", result.paywalls.first().id)
         assertEquals("placement-1", result.placements.first().id)
 
         coVerify {
             userRepository.setCurrentUser(match { user ->
-                user.paywalls.isNotEmpty() && user.placements.isNotEmpty()
+                user.placements.isNotEmpty()
             })
         }
     }
 
     @Test
     fun `when backend returns new placements, they replace cached ones`() = runTest {
-        val cachedPaywall = ApphudPaywall(
-            id = "old-paywall",
-            name = "Old Paywall",
-            identifier = "old_paywall",
-            default = false,
-            json = null,
-            products = null,
-            screen = null,
-            experimentName = null,
-            variationName = null,
-            parentPaywallIdentifier = null,
-            placementIdentifier = null,
-            placementId = null
-        )
         val cachedUser = ApphudUser(
             userId = "user-1",
             currencyCode = "USD",
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = listOf(cachedPaywall),
             placements = emptyList(),
             isTemporary = false
         )
 
-        val newPaywall = ApphudPaywall(
-            id = "new-paywall",
-            name = "New Paywall",
-            identifier = "new_paywall",
-            default = true,
-            json = null,
-            products = null,
-            screen = null,
-            experimentName = null,
-            variationName = null,
-            parentPaywallIdentifier = null,
-            placementIdentifier = null,
-            placementId = null
+        val newPlacement = ApphudPlacement(
+            identifier = "new_placement",
+            paywall = null,
+            id = "new-placement"
         )
         val newUserFromBackend = ApphudUser(
             userId = "user-1",
@@ -411,8 +381,7 @@ class RegistrationUseCaseTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = listOf(newPaywall),
-            placements = emptyList(),
+            placements = listOf(newPlacement),
             isTemporary = false
         )
 
@@ -426,29 +395,15 @@ class RegistrationUseCaseTest {
             forceRegistration = true
         )
 
-        assertEquals(1, result.paywalls.size)
-        assertEquals("new-paywall", result.paywalls.first().id)
+        assertEquals(1, result.placements.size)
+        assertEquals("new-placement", result.placements.first().id)
     }
 
     @Test
-    fun `when backend returns empty paywalls but non-empty placements, only paywalls are preserved`() = runTest {
-        val cachedPaywall = ApphudPaywall(
-            id = "cached-paywall",
-            name = "Cached Paywall",
-            identifier = "cached_paywall",
-            default = false,
-            json = null,
-            products = null,
-            screen = null,
-            experimentName = null,
-            variationName = null,
-            parentPaywallIdentifier = null,
-            placementIdentifier = null,
-            placementId = null
-        )
+    fun `when backend returns non-empty placements, new placements replace cached ones`() = runTest {
         val cachedPlacement = ApphudPlacement(
             identifier = "cached_placement",
-            paywall = cachedPaywall,
+            paywall = null,
             id = "cached-placement"
         )
         val cachedUser = ApphudUser(
@@ -457,7 +412,6 @@ class RegistrationUseCaseTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = listOf(cachedPaywall),
             placements = listOf(cachedPlacement),
             isTemporary = false
         )
@@ -473,7 +427,6 @@ class RegistrationUseCaseTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = emptyList(),
             placements = listOf(newPlacement),
             isTemporary = false
         )
@@ -488,82 +441,8 @@ class RegistrationUseCaseTest {
             forceRegistration = true
         )
 
-        assertEquals("Cached paywalls should be preserved", 1, result.paywalls.size)
-        assertEquals("cached-paywall", result.paywalls.first().id)
         assertEquals("New placements should be used", 1, result.placements.size)
         assertEquals("new-placement", result.placements.first().id)
     }
 
-    @Test
-    fun `when backend returns non-empty paywalls but empty placements, only placements are preserved`() = runTest {
-        val cachedPaywall = ApphudPaywall(
-            id = "cached-paywall",
-            name = "Cached Paywall",
-            identifier = "cached_paywall",
-            default = false,
-            json = null,
-            products = null,
-            screen = null,
-            experimentName = null,
-            variationName = null,
-            parentPaywallIdentifier = null,
-            placementIdentifier = null,
-            placementId = null
-        )
-        val cachedPlacement = ApphudPlacement(
-            identifier = "cached_placement",
-            paywall = cachedPaywall,
-            id = "cached-placement"
-        )
-        val cachedUser = ApphudUser(
-            userId = "user-1",
-            currencyCode = "USD",
-            countryCode = "US",
-            subscriptions = emptyList(),
-            purchases = emptyList(),
-            paywalls = listOf(cachedPaywall),
-            placements = listOf(cachedPlacement),
-            isTemporary = false
-        )
-
-        val newPaywall = ApphudPaywall(
-            id = "new-paywall",
-            name = "New Paywall",
-            identifier = "new_paywall",
-            default = true,
-            json = null,
-            products = null,
-            screen = null,
-            experimentName = null,
-            variationName = null,
-            parentPaywallIdentifier = null,
-            placementIdentifier = null,
-            placementId = null
-        )
-        val newUserFromBackend = ApphudUser(
-            userId = "user-1",
-            currencyCode = "USD",
-            countryCode = "US",
-            subscriptions = emptyList(),
-            purchases = emptyList(),
-            paywalls = listOf(newPaywall),
-            placements = emptyList(),
-            isTemporary = false
-        )
-
-        every { userRepository.getCurrentUser() } returns cachedUser
-        coEvery { requestManager.registration(any(), any(), any(), any(), any()) } returns newUserFromBackend
-        coEvery { userRepository.setCurrentUser(any()) } returns true
-
-        val result = registrationUseCase(
-            needPlacementsPaywalls = true,
-            isNew = false,
-            forceRegistration = true
-        )
-
-        assertEquals("New paywalls should be used", 1, result.paywalls.size)
-        assertEquals("new-paywall", result.paywalls.first().id)
-        assertEquals("Cached placements should be preserved", 1, result.placements.size)
-        assertEquals("cached-placement", result.placements.first().id)
-    }
 }

--- a/sdk/src/test/java/com/apphud/sdk/storage/SharedPreferencesStorageMigrationTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/storage/SharedPreferencesStorageMigrationTest.kt
@@ -77,11 +77,10 @@ class SharedPreferencesStorageMigrationTest {
     }
 
     @Test
-    fun `migration from v2 to v3 should transfer paywalls to user when user has empty paywalls`() {
-        // Arrange: Set up v2 cache with user (empty paywalls) and separate paywalls cache
-        val userWithEmptyPaywalls = createTestUser(
+    fun `migration from v2 to v3 should transfer placements to user when user has empty placements`() {
+        // Arrange: Set up v2 cache with user (empty placements) and separate placements cache
+        val userWithEmptyPlacements = createTestUser(
             userId = "test-user-id",
-            paywalls = emptyList(),
             placements = emptyList()
         )
         val legacyPaywalls = listOf(
@@ -92,7 +91,7 @@ class SharedPreferencesStorageMigrationTest {
             createTestPlacement("placement-1", "onboarding")
         )
 
-        setupV2Cache(userWithEmptyPaywalls, legacyPaywalls, legacyPlacements)
+        setupV2Cache(userWithEmptyPlacements, legacyPaywalls, legacyPlacements)
 
         // Act: Initialize storage (triggers migration)
         val storage = SharedPreferencesStorage(context)
@@ -102,7 +101,7 @@ class SharedPreferencesStorageMigrationTest {
         assertTrue("Cache should be valid after migration", isValid)
         assertEquals("Cache version should be 3", "3", prefsMap[CACHE_VERSION_KEY])
 
-        // Verify migrated user has paywalls
+        // Verify migrated user has placements
         val migratedUserJson = prefsMap[APPHUD_USER_KEY] as? String
         assertNotNull("User JSON should exist after migration", migratedUserJson)
 
@@ -111,12 +110,11 @@ class SharedPreferencesStorageMigrationTest {
             object : TypeToken<ApphudUser>() {}.type
         )
         assertNotNull("User should be deserializable", migratedUser)
-        assertEquals("User should have 2 paywalls", 2, migratedUser?.paywalls?.size)
         assertEquals("User should have 1 placement", 1, migratedUser?.placements?.size)
         assertEquals(
-            "First paywall identifier should match",
-            "main_paywall",
-            migratedUser?.paywalls?.get(0)?.identifier
+            "First placement identifier should match",
+            "onboarding",
+            migratedUser?.placements?.get(0)?.identifier
         )
 
         // Legacy keys should be cleared
@@ -125,19 +123,21 @@ class SharedPreferencesStorageMigrationTest {
     }
 
     @Test
-    fun `migration from v2 to v3 should not overwrite user paywalls if user already has paywalls`() {
-        // Arrange: User already has paywalls, legacy cache also has paywalls
-        val existingPaywalls = listOf(createTestPaywall("existing-1", "existing_paywall"))
-        val userWithPaywalls = createTestUser(
+    fun `migration from v2 to v3 should not overwrite user placements if user already has placements`() {
+        // Arrange: User already has placements, legacy cache also has placements
+        val existingPlacement = createTestPlacement("existing-1", "existing_placement")
+        val userWithPlacements = createTestUser(
             userId = "test-user-id",
-            paywalls = existingPaywalls,
-            placements = emptyList()
+            placements = listOf(existingPlacement)
         )
         val legacyPaywalls = listOf(
             createTestPaywall("legacy-1", "legacy_paywall")
         )
+        val legacyPlacements = listOf(
+            createTestPlacement("legacy-pl-1", "legacy_placement")
+        )
 
-        setupV2Cache(userWithPaywalls, legacyPaywalls, emptyList())
+        setupV2Cache(userWithPlacements, legacyPaywalls, legacyPlacements)
 
         // Act
         val storage = SharedPreferencesStorage(context)
@@ -152,11 +152,11 @@ class SharedPreferencesStorageMigrationTest {
             object : TypeToken<ApphudUser>() {}.type
         )
         assertNotNull("User should exist after migration", migratedUser)
-        assertEquals("User should keep original paywall count", 1, migratedUser?.paywalls?.size)
+        assertEquals("User should keep original placement count", 1, migratedUser?.placements?.size)
         assertEquals(
-            "User should keep existing paywall identifier",
-            "existing_paywall",
-            migratedUser?.paywalls?.get(0)?.identifier
+            "User should keep existing placement identifier",
+            "existing_placement",
+            migratedUser?.placements?.get(0)?.identifier
         )
 
         // Legacy keys should still be cleared
@@ -168,7 +168,6 @@ class SharedPreferencesStorageMigrationTest {
         // Arrange: User exists, but no legacy paywalls/placements
         val user = createTestUser(
             userId = "test-user-id",
-            paywalls = emptyList(),
             placements = emptyList()
         )
 
@@ -188,7 +187,7 @@ class SharedPreferencesStorageMigrationTest {
             object : TypeToken<ApphudUser>() {}.type
         )
         assertNotNull("User should exist after migration", migratedUser)
-        assertTrue("User paywalls should remain empty", migratedUser?.paywalls?.isEmpty() == true)
+        assertTrue("User placements should remain empty", migratedUser?.placements?.isEmpty() == true)
     }
 
     @Test
@@ -216,7 +215,7 @@ class SharedPreferencesStorageMigrationTest {
     @Test
     fun `validateCaches should clear all caches for invalid version`() {
         // Arrange: Invalid cache version (version 1)
-        val user = createTestUser("test-user", emptyList(), emptyList())
+        val user = createTestUser("test-user", emptyList())
 
         prefsMap[CACHE_VERSION_KEY] = "1"
         prefsMap[APPHUD_USER_KEY] = parser.toJson(user)
@@ -237,8 +236,7 @@ class SharedPreferencesStorageMigrationTest {
         // Arrange: Already on v3
         val user = createTestUser(
             userId = "test-user",
-            paywalls = listOf(createTestPaywall("p1", "paywall")),
-            placements = emptyList()
+            placements = listOf(createTestPlacement("pl1", "placement"))
         )
 
         prefsMap[CACHE_VERSION_KEY] = "3"
@@ -257,13 +255,13 @@ class SharedPreferencesStorageMigrationTest {
             object : TypeToken<ApphudUser>() {}.type
         )
         assertNotNull("User should exist", storedUser)
-        assertEquals("User paywalls should be preserved", 1, storedUser?.paywalls?.size)
+        assertEquals("User placements should be preserved", 1, storedUser?.placements?.size)
     }
 
     @Test
     fun `validateCaches should handle null cache version`() {
         // Arrange: No cache version set (fresh install or corrupted)
-        val user = createTestUser("test-user", emptyList(), emptyList())
+        val user = createTestUser("test-user", emptyList())
         prefsMap[APPHUD_USER_KEY] = parser.toJson(user)
         // No CACHE_VERSION_KEY set
 
@@ -280,7 +278,6 @@ class SharedPreferencesStorageMigrationTest {
 
     private fun createTestUser(
         userId: String,
-        paywalls: List<ApphudPaywall>,
         placements: List<ApphudPlacement>,
     ): ApphudUser {
         return ApphudUser(
@@ -289,7 +286,6 @@ class SharedPreferencesStorageMigrationTest {
             countryCode = "US",
             subscriptions = emptyList(),
             purchases = emptyList(),
-            paywalls = paywalls,
             placements = placements,
             isTemporary = false
         )


### PR DESCRIPTION
Remove the `paywalls` property from `ApphudUser` and all related public APIs (`rawPaywalls`, `paywallsDidLoadCallback`, `paywallClosed`, `paywallsDidFullyLoad` listener callback). Paywalls are now accessed exclusively through placements.

- Remove `paywalls` from ApphudUser, CustomerDto, CustomerMapper, RegistrationBody, and SharedPreferencesStorage migration
- Remove `need_paywalls` request field, rename to `needPlacements`
- Update all internal logic to use placements instead of paywalls: ApphudInternal, fallback handling, product loading, purchases, restore purchases
- Extract `findPaywallScreenId` helper in ApphudInternal+Purchases to eliminate duplicated paywall lookup logic
- Use `firstNotNullOfOrNull` in PaywallRepository for consistency and to avoid intermediate list allocation
- Update demos and all unit tests accordingly