### PR TITLE
Refactor service locator

### DIFF
--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application>
+        <provider
+            android:name=".internal.ApphudInitProvider"
+            android:authorities="${applicationId}.apphud-init"
+            android:exported="false" />
+
         <activity
             android:name=".internal.presentation.rule.RuleWebViewActivity"
             android:exported="false"

--- a/sdk/src/main/java/com/apphud/sdk/Apphud.kt
+++ b/sdk/src/main/java/com/apphud/sdk/Apphud.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
-import com.apphud.sdk.ApphudInternal.coroutineScope
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.domain.ApphudGroup
 import com.apphud.sdk.domain.ApphudNonRenewingPurchase
@@ -16,7 +15,6 @@ import com.apphud.sdk.domain.ApphudSubscription
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.internal.ServiceLocator
 import com.apphud.sdk.internal.domain.model.ApiKey as ApiKeyModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -24,6 +22,9 @@ import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
 
 object Apphud {
+    private val coroutineScope get() = ApphudInternal.coroutineScope
+    private val dispatchers get() = ApphudInternal.dispatchers
+
     //region === Initialization ===
 
     /**
@@ -118,12 +119,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.updateUserId(userId)
             }.onSuccess { result ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(result)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in updateUserId: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(null)
                 }
             }
@@ -519,7 +520,7 @@ object Apphud {
     ) {
         val wrappedCallback: ((ApphudPurchaseResult) -> Unit)? = block?.let { callback ->
             { result ->
-                coroutineScope.launch(Dispatchers.Main) {
+                coroutineScope.launch(dispatchers.main) {
                     callback(result)
                 }
             }
@@ -561,7 +562,7 @@ object Apphud {
     ) {
         val wrappedCallback: ((ApphudPurchaseResult) -> Unit)? = block?.let { callback ->
             { result ->
-                coroutineScope.launch(Dispatchers.Main) {
+                coroutineScope.launch(dispatchers.main) {
                     callback(result)
                 }
             }
@@ -629,12 +630,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.restorePurchases()
             }.onSuccess { result ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback(result)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in restorePurchases: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback(ApphudPurchasesRestoreResult.Error(error.toApphudError()))
                 }
             }
@@ -657,12 +658,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.refreshEntitlements(forceRefresh = true)
             }.onSuccess { result ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(result)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in refreshUserData: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(null)
                 }
             }
@@ -749,12 +750,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.tryWebAttribution(data = data)
             }.onSuccess { (success, user) ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback(success, user)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in attributeFromWeb: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback(false, null)
                 }
             }
@@ -820,12 +821,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.userPropertiesManager.forceFlushUserProperties(true)
             }.onSuccess { result ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     completion?.invoke(result)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in forceFlushUserProperties: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     completion?.invoke(false)
                 }
             }
@@ -878,12 +879,12 @@ object Apphud {
             runCatchingCancellable {
                 ApphudInternal.grantPromotionalSuspend(daysCount, productId, permissionGroup)
             }.onSuccess { result ->
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(result)
                 }
             }.onFailure { error ->
                 ApphudLog.logE("Error in grantPromotional: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callback?.invoke(false)
                 }
             }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Attribution.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Attribution.kt
@@ -17,7 +17,6 @@ import com.apphud.sdk.domain.FacebookInfo
 import com.apphud.sdk.internal.data.dto.AttributionRequestDto
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -109,7 +108,7 @@ internal fun ApphudInternal.setAttribution(
             )
             RequestManager.send(requestBody)
                 .onSuccess {
-                    withContext(Dispatchers.Main) {
+                    withContext(dispatchers.main) {
                         when (provider) {
                             APPSFLYER -> {
                                 storage.appsflyer = AppsflyerInfo(

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Fallback.kt
@@ -62,7 +62,7 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
 
         if (ids.isEmpty()) {
             val error = ApphudError("Invalid Paywalls Fallback File")
-            mainScope.launch {
+            coroutineScope.launch(dispatchers.main) {
                 callback(null, error)
             }
             return
@@ -82,7 +82,7 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
             ) else ApphudError("Google Billing error", errorCode = response.first))
             val details = response.second ?: productDetails
             val user = userRepository.getCurrentUser()
-            mainScope.launch {
+            coroutineScope.launch(dispatchers.main) {
                 notifyLoadingCompleted(
                     customerLoaded = user,
                     productDetailsLoaded = details,
@@ -94,7 +94,7 @@ internal fun ApphudInternal.processFallbackData(callback: PaywallCallback) {
     } catch (ex: Exception) {
         val error = ApphudError("Fallback Mode Failed: ${ex.message}")
         ApphudLog.logE("Fallback Mode Failed: ${ex.message}")
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             callback(null, error)
         }
     }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Products.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Products.kt
@@ -68,7 +68,7 @@ internal fun ApphudInternal.loadProducts() {
 
 internal fun respondWithProducts() {
     ApphudInternal.productRepository.markAsResponded()
-    ApphudInternal.mainScope.launch {
+    ApphudInternal.coroutineScope.launch(ApphudInternal.dispatchers.main) {
         ApphudInternal.notifyLoadingCompleted(productDetailsLoaded = ApphudInternal.productRepository.state.value.products)
     }
 }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Purchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+Purchases.kt
@@ -14,7 +14,6 @@ import com.apphud.sdk.internal.callback_status.PurchaseUpdatedCallbackStatus
 import com.apphud.sdk.internal.domain.model.PurchaseContext
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -104,7 +103,7 @@ private suspend fun ApphudInternal.fetchDetailsAndPurchase(
     val responseCode = fetchDetails(listOf(apphudProduct.productId))
     val productDetails = responseCode.second?.firstOrNull() ?: getProductDetailsByProductId(apphudProduct.productId)
     if (productDetails != null) {
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             apphudProduct.productDetails = productDetails
             purchaseInternal(
                 activity,
@@ -121,7 +120,7 @@ private suspend fun ApphudInternal.fetchDetailsAndPurchase(
         val message =
             "[${ApphudBillingResponseCodes.getName(responseCode.first)}] Aborting purchase because product unavailable: ${apphudProduct.productId}"
         ApphudLog.log(message = message)
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             callback?.invoke(
                 ApphudPurchaseResult(
                     null,
@@ -174,7 +173,7 @@ private fun ApphudInternal.purchaseInternal(
 
         coroutineScope.launch {
             billing.purchasesCallback = { purchasesResult ->
-                mainScope.launch {
+                coroutineScope.launch(dispatchers.main) {
                     when (purchasesResult) {
                         is PurchaseUpdatedCallbackStatus.Error -> {
                             val message =
@@ -281,7 +280,7 @@ private fun ApphudInternal.purchaseInternal(
             if (error != null) {
                 billing.purchasesCallback = null
                 purchasingProduct = null
-                mainScope.launch {
+                coroutineScope.launch(dispatchers.main) {
                     callback?.invoke(ApphudPurchaseResult(null, null, null, error))
                 }
             }
@@ -290,7 +289,7 @@ private fun ApphudInternal.purchaseInternal(
         val message =
             "Unable to buy product with because ProductDetails is null [Apphud product ID: ${apphudProduct.id}]"
         ApphudLog.log(message = message)
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             callback?.invoke(ApphudPurchaseResult(null, null, null, ApphudError(message)))
         }
     }
@@ -310,7 +309,7 @@ internal fun ApphudInternal.lookupFreshPurchase(extraMessage: String = "resend_f
             }
             if ((purchaseCallbacks.isNotEmpty() && purchasingProduct != null) || storage.isNeedSync) {
 
-                launch(Dispatchers.Main) { apphudListener?.apphudDidReceivePurchase(purchase) }
+                launch(dispatchers.main) { apphudListener?.apphudDidReceivePurchase(purchase) }
 
                 ApphudLog.logE("resending fresh purchase ${purchase.orderId}")
 
@@ -328,7 +327,7 @@ internal fun ApphudInternal.lookupFreshPurchase(extraMessage: String = "resend_f
                     )
                 )
 
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     val newSubscriptions =
                         customer.subscriptions.firstOrNull { it.productId == purchase.products.first() }
                     val newPurchases =
@@ -351,7 +350,7 @@ private suspend fun ApphudInternal.handlePurchaseAcknowledgment(
 ) {
     ApphudLog.log("Start $productType purchase acknowledge")
     billing.acknowledge(purchase) { status, _ ->
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             when (status) {
                 is PurchaseCallbackStatus.Error -> {
                     val message =
@@ -369,7 +368,7 @@ private suspend fun ApphudInternal.handlePurchaseAcknowledgment(
 private suspend fun ApphudInternal.handlePurchaseConsumption(purchase: Purchase, apphudProduct: ApphudProduct?) {
     ApphudLog.log("Start inapp consume purchase")
     billing.consume(purchase) { status, _ ->
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             when (status) {
                 is PurchaseCallbackStatus.Error -> {
                     val message =
@@ -471,7 +470,7 @@ private suspend fun ApphudInternal.sendCheckToApphud(
             }.onFailure { error ->
                 ApphudLog.logE("Failed to send purchase in fallback mode: ${error.message}")
             }
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main) {
                 addTempPurchase(
                     apphudUser = localCurrentUser, purchase = purchase,
                     type = apphudProduct?.productDetails?.productType ?: productDetails?.productType ?: "",
@@ -505,7 +504,7 @@ private suspend fun ApphudInternal.sendCheckToApphud(
                 )
             }
                 .onSuccess { customer ->
-                    withContext(Dispatchers.IO) {
+                    withContext(dispatchers.io) {
                         val newSubscriptions =
                             customer.subscriptions.firstOrNull { it.productId == purchase.products.first() }
                         val newPurchases =
@@ -648,7 +647,7 @@ internal suspend fun ApphudInternal.trackPurchase(
         }
     } else {
         storage.isNeedSync = true
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main) {
             syncPurchases(observerMode = true)
         }
     }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal+RestorePurchases.kt
@@ -8,7 +8,6 @@ import com.apphud.sdk.domain.PurchaseRecordDetails
 import com.apphud.sdk.internal.callback_status.PurchaseRestoredCallbackStatus
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -154,7 +153,7 @@ internal suspend fun ApphudInternal.sendPurchasesToApphud(
             storage.isNeedSync = false
             prevPurchases.addAll(tempPurchaseRecordDetails)
 
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main) {
                 ApphudLog.log("SyncPurchases: success $customer")
                 notifyLoadingCompleted(customerLoaded = customer)
             }

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
@@ -171,10 +171,11 @@ internal object ApphudInternal {
         this.context = context.applicationContext
         this.apiKey = apiKey
 
-        ServiceLocator.ServiceLocatorInstanceFactory().create(
-            applicationContext = context.applicationContext,
+        ServiceLocator.initSessionScope(
+            apiKey = ApiKeyModel(apiKey),
             ruleCallback = ruleCallback,
-            apiKey = ApiKeyModel(apiKey)
+            coroutineScope = coroutineScope,
+            awaitUserRegistration = { awaitUserRegistration() },
         )
 
         mainScope.launch {
@@ -900,7 +901,7 @@ internal object ApphudInternal {
         }.onFailure { e ->
             ApphudLog.log("ServiceLocator not initialized, skip managers clear: ${e.message}")
         }
-        ServiceLocator.clearInstance()
+        ServiceLocator.clearSession()
         RequestManager.cleanRegistration()
         purchaseCallbacks.clear()
         freshPurchase = null

--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
@@ -18,6 +18,7 @@ import com.apphud.sdk.domain.ApphudProduct
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.domain.PaywallEvent
 import com.apphud.sdk.domain.PurchaseRecordDetails
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.BillingWrapper
 import com.apphud.sdk.internal.ServiceLocator
 import com.apphud.sdk.internal.data.ProductLoadingState
@@ -27,10 +28,7 @@ import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
 import com.apphud.sdk.storage.SharedPreferencesStorage
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -45,8 +43,10 @@ import kotlin.math.max
 @SuppressLint("StaticFieldLeak")
 internal object ApphudInternal {
     //region === Variables ===
-    internal var mainScope = CoroutineScope(Dispatchers.Main)
-    internal var coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    internal val coroutineScope: CoroutineScope
+        get() = ServiceLocator.instance.coroutineScope
+    internal val dispatchers: ApphudDispatchers
+        get() = ServiceLocator.instance.dispatchers
 
     internal val FALLBACK_ERRORS = listOf(APPHUD_ERROR_TIMEOUT, 404, 500, 502, 503)
     internal var ignoreCache: Boolean = false
@@ -174,11 +174,10 @@ internal object ApphudInternal {
         ServiceLocator.initSessionScope(
             apiKey = ApiKeyModel(apiKey),
             ruleCallback = ruleCallback,
-            coroutineScope = coroutineScope,
             awaitUserRegistration = { awaitUserRegistration() },
         )
 
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
             ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleEventObserver)
         }
 
@@ -214,7 +213,7 @@ internal object ApphudInternal {
                 runCatchingCancellable { registration() }
                     .onFailure { ApphudLog.logE("Registration failed in initialize: ${it.message}") }
             } else {
-                mainScope.launch { notifyLoadingCompleted(customerLoaded = userRepository.getCurrentUser()) }
+                coroutineScope.launch(dispatchers.main) { notifyLoadingCompleted(customerLoaded = userRepository.getCurrentUser()) }
             }
             postInitSetup()
         }
@@ -321,7 +320,7 @@ internal object ApphudInternal {
             // TODO: should be called only if something changed
             coroutineScope.launch {
                 delay(500)
-                mainScope.launch {
+                coroutineScope.launch(dispatchers.main) {
                     userRepository.getCurrentUser()?.let { user ->
                         apphudListener?.apphudNonRenewingPurchasesUpdated(user.purchases.toList())
                         apphudListener?.apphudSubscriptionsUpdated(user.subscriptions.toList())
@@ -442,7 +441,7 @@ internal object ApphudInternal {
             isRegisteringUser = false
 
             val cachedUser = userRepository.getCurrentUser()
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main) {
                 notifyLoadingCompleted(
                     customerLoaded = cachedUser,
                     productDetailsLoaded = null,
@@ -461,7 +460,7 @@ internal object ApphudInternal {
                 return@launch
             }
             delay((preferredTimeout * 1000.0 * 1.5).toLong())
-            mainScope.launch {
+            coroutineScope.launch(dispatchers.main) {
                 if (offeringsCallbackManager.hasPendingWork()) {
                     ApphudLog.logE("Force Notify About Current State")
                     notifyLoadingCompleted(
@@ -491,7 +490,7 @@ internal object ApphudInternal {
             // Retry counts are now managed by state transitions
         }
 
-        mainScope.launch {
+        coroutineScope.launch(dispatchers.main) {
 
             if (observerMode) {
                 observerMode = false
@@ -582,7 +581,7 @@ internal object ApphudInternal {
         }
 
         customer?.let {
-            mainScope.launch { notifyLoadingCompleted(customerLoaded = it) }
+            coroutineScope.launch(dispatchers.main) { notifyLoadingCompleted(customerLoaded = it) }
         }
         return userRepository.getCurrentUser()
     }
@@ -609,7 +608,7 @@ internal object ApphudInternal {
             val eventsJob = launch {
                 try {
                     ServiceLocator.instance.paywallEventManager.events.collect { event ->
-                        withContext(Dispatchers.Main) {
+                        withContext(dispatchers.main) {
                             when (event) {
                                 is PaywallEvent.ScreenShown -> {
                                     ApphudLog.logI("[ApphudInternal] Paywall screen shown via event bus")
@@ -648,7 +647,7 @@ internal object ApphudInternal {
                 } catch (e: Exception) {
                     val error = e.toApphudError()
                     ApphudLog.logE("[ApphudInternal] Error in event subscription: ${error.message}")
-                    withContext(Dispatchers.Main) {
+                    withContext(dispatchers.main) {
                         callbacks.onScreenError(error)
                     }
                 }
@@ -672,7 +671,7 @@ internal object ApphudInternal {
                 eventsJob.cancel()
                 val error = e.toApphudError()
                 ApphudLog.logE("[ApphudInternal] Timeout showing paywall screen: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callbacks.onScreenError(error)
                 }
                 throw e
@@ -683,7 +682,7 @@ internal object ApphudInternal {
                 eventsJob.cancel()
                 val error = e.toApphudError()
                 ApphudLog.logE("[ApphudInternal] Error showing paywall screen: ${error.message}")
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     callbacks.onScreenError(error)
                 }
             }
@@ -832,7 +831,7 @@ internal object ApphudInternal {
                     needPlacementsPaywalls = needPP,
                     isNew = isNew,
                 )
-                user?.let { mainScope.launch { notifyLoadingCompleted(customerLoaded = it) } }
+                user?.let { coroutineScope.launch(dispatchers.main) { notifyLoadingCompleted(customerLoaded = it) } }
             }.onFailure { ApphudLog.logE("Error collecting device identifiers: ${it.message}") }
         }
     }
@@ -854,53 +853,6 @@ internal object ApphudInternal {
     }
 
     private fun clear() {
-        // Cancel all active coroutines to prevent race conditions when userId/deviceId become null
-        coroutineScope.cancel()
-        mainScope.cancel()
-
-        // Recreate scopes for next initialization
-        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-        mainScope = CoroutineScope(Dispatchers.Main)
-
-        runCatching {
-            val controller = ServiceLocator.instance.ruleController
-            controller.stop()
-        }.onFailure { e ->
-            ApphudLog.log("ServiceLocator not initialized, skip ruleController.stop(): ${e.message}")
-        }
-
-        // Clear user through Repository
-        runCatching {
-            userRepository.clearUser()
-        }.onFailure { e ->
-            ApphudLog.log("ServiceLocator not initialized, skip userRepository.clearUser(): ${e.message}")
-        }
-
-        // Reset products state to Idle
-        runCatching {
-            productRepository.reset()
-        }.onFailure { e ->
-            ApphudLog.log("ServiceLocator not initialized, skip productRepository.reset(): ${e.message}")
-        }
-
-        runCatching {
-            ServiceLocator.instance.deviceIdentifiersRepository.clear()
-        }.onFailure { e ->
-            ApphudLog.log("ServiceLocator not initialized, skip deviceIdentifiersRepository.clear(): ${e.message}")
-        }
-
-        if (isInitialized()) {
-            storage.clean()
-        } else {
-            ApphudLog.log("SDK not initialized, skip storage.clean()")
-        }
-        runCatching {
-            offeringsCallbackManager.clear()
-            userPropertiesManager.clear()
-            analyticsTracker.reset()
-        }.onFailure { e ->
-            ApphudLog.log("ServiceLocator not initialized, skip managers clear: ${e.message}")
-        }
         ServiceLocator.clearSession()
         RequestManager.cleanRegistration()
         purchaseCallbacks.clear()
@@ -961,7 +913,7 @@ internal object ApphudInternal {
         val userIdChanged = userRepository.setCurrentUser(user)
         if (userIdChanged && !fromFallback) {
             val newUserId = user.userId
-            mainScope.launch {
+            coroutineScope.launch(dispatchers.main) {
                 apphudListener?.apphudDidChangeUserID(newUserId)
             }
         }

--- a/sdk/src/main/java/com/apphud/sdk/flutter/ApphudFlutter.kt
+++ b/sdk/src/main/java/com/apphud/sdk/flutter/ApphudFlutter.kt
@@ -2,7 +2,6 @@ package com.apphud.sdk.flutter
 
 import android.app.Activity
 import com.apphud.sdk.ApphudInternal
-import com.apphud.sdk.ApphudInternal.coroutineScope
 import com.apphud.sdk.ApphudLog
 import com.apphud.sdk.ApphudPurchaseResult
 import com.apphud.sdk.internal.util.runCatchingCancellable
@@ -22,7 +21,7 @@ object ApphudFlutter {
         paywallIdentifier: String? = null,
         placementIdentifier: String? = null,
     ) {
-        coroutineScope.launch {
+        ApphudInternal.coroutineScope.launch {
             runCatchingCancellable {
                 ApphudInternal.syncPurchases(paywallIdentifier, placementIdentifier)
             }.onFailure { error ->

--- a/sdk/src/main/java/com/apphud/sdk/internal/AppScopeComponent.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/AppScopeComponent.kt
@@ -1,0 +1,62 @@
+package com.apphud.sdk.internal
+
+import android.content.Context
+import com.apphud.sdk.internal.data.DeviceIdentifiersDataSource
+import com.apphud.sdk.internal.data.DeviceIdentifiersRepository
+import com.apphud.sdk.internal.data.local.LifecycleRepository
+import com.apphud.sdk.internal.data.local.LocalRulesScreenRepository
+import com.apphud.sdk.internal.data.mapper.CustomerMapper
+import com.apphud.sdk.internal.data.mapper.PaywallsMapper
+import com.apphud.sdk.internal.data.mapper.PlacementsMapper
+import com.apphud.sdk.internal.data.mapper.RuleScreenMapper
+import com.apphud.sdk.internal.data.mapper.SubscriptionMapper
+import com.apphud.sdk.internal.data.network.HostSwitcherInterceptor
+import com.apphud.sdk.internal.data.network.PrettyHttpLoggingInterceptor
+import com.apphud.sdk.internal.data.network.PrettyJsonFormatter
+import com.apphud.sdk.internal.data.network.UrlProvider
+import com.apphud.sdk.storage.SharedPreferencesStorage
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
+
+internal class AppScopeComponent(val applicationContext: Context) {
+
+    val gson: Gson = Gson()
+
+    val storage: SharedPreferencesStorage = SharedPreferencesStorage(applicationContext)
+
+    private val paywallsMapper = PaywallsMapper(gson)
+    private val placementsMapper = PlacementsMapper(paywallsMapper)
+    private val subscriptionMapper = SubscriptionMapper()
+    val customerMapper = CustomerMapper(subscriptionMapper, placementsMapper)
+
+    val deviceIdentifiersDataSource: DeviceIdentifiersDataSource =
+        DeviceIdentifiersDataSource(applicationContext, storage)
+
+    val deviceIdentifiersRepository: DeviceIdentifiersRepository =
+        DeviceIdentifiersRepository(deviceIdentifiersDataSource)
+
+    val urlProvider = UrlProvider()
+
+    val hostSwitcherInterceptor = HostSwitcherInterceptor(OkHttpClient(), urlProvider)
+    val hostSwitcherInterceptorWithoutHeaders = HostSwitcherInterceptor(OkHttpClient(), urlProvider)
+
+    val prettyGson: Gson by lazy {
+        GsonBuilder().setPrettyPrinting().create()
+    }
+    val prettyJsonFormatter: PrettyJsonFormatter by lazy { PrettyJsonFormatter(prettyGson) }
+    val prettyLoggingInterceptor: PrettyHttpLoggingInterceptor by lazy {
+        PrettyHttpLoggingInterceptor(prettyJsonFormatter)
+    }
+
+    val localRulesScreenRepository: LocalRulesScreenRepository =
+        LocalRulesScreenRepository(
+            context = applicationContext,
+            gson = gson,
+            ruleScreenMapper = RuleScreenMapper()
+        )
+
+    val lifecycleRepository: LifecycleRepository = LifecycleRepository()
+
+    val billingWrapper: BillingWrapper by lazy { BillingWrapper(applicationContext) }
+}

--- a/sdk/src/main/java/com/apphud/sdk/internal/AppScopeComponent.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/AppScopeComponent.kt
@@ -21,6 +21,8 @@ import okhttp3.OkHttpClient
 
 internal class AppScopeComponent(val applicationContext: Context) {
 
+    val dispatchers: ApphudDispatchers = ApphudDispatchers()
+
     val gson: Gson = Gson()
 
     val storage: SharedPreferencesStorage = SharedPreferencesStorage(applicationContext)
@@ -53,10 +55,11 @@ internal class AppScopeComponent(val applicationContext: Context) {
         LocalRulesScreenRepository(
             context = applicationContext,
             gson = gson,
-            ruleScreenMapper = RuleScreenMapper()
+            ruleScreenMapper = RuleScreenMapper(),
+            dispatchers = dispatchers,
         )
 
-    val lifecycleRepository: LifecycleRepository = LifecycleRepository()
+    val lifecycleRepository: LifecycleRepository = LifecycleRepository(dispatchers)
 
     val billingWrapper: BillingWrapper by lazy { BillingWrapper(applicationContext) }
 }

--- a/sdk/src/main/java/com/apphud/sdk/internal/ApphudDispatchers.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ApphudDispatchers.kt
@@ -1,0 +1,11 @@
+package com.apphud.sdk.internal
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+internal class ApphudDispatchers(
+    val main: CoroutineDispatcher = Dispatchers.Main,
+    val io: CoroutineDispatcher = Dispatchers.IO,
+    val default: CoroutineDispatcher = Dispatchers.Default,
+    val unconfined: CoroutineDispatcher = Dispatchers.Unconfined,
+)

--- a/sdk/src/main/java/com/apphud/sdk/internal/ApphudInitProvider.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ApphudInitProvider.kt
@@ -1,0 +1,36 @@
+package com.apphud.sdk.internal
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+internal class ApphudInitProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        val ctx = context?.applicationContext ?: return false
+        ServiceLocator.initAppScope(ctx)
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}

--- a/sdk/src/main/java/com/apphud/sdk/internal/PurchasesUpdated.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/PurchasesUpdated.kt
@@ -5,8 +5,6 @@ import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.apphud.sdk.ApphudInternal
 import com.apphud.sdk.ApphudInternal.apphudListener
-import com.apphud.sdk.ApphudInternal.coroutineScope
-import com.apphud.sdk.ApphudInternal.mainScope
 import com.apphud.sdk.BuildConfig
 import com.apphud.sdk.handleObservedPurchase
 import com.apphud.sdk.internal.callback_status.PurchaseUpdatedCallbackStatus
@@ -32,7 +30,7 @@ internal class PurchasesUpdated(
                         if (it.purchaseState == Purchase.PurchaseState.PURCHASED) {
                             ApphudInternal.freshPurchase = purchase
                         }
-                        mainScope.launch {
+                        ApphudInternal.coroutineScope.launch(ApphudInternal.dispatchers.main) {
                             apphudListener?.apphudDidReceivePurchase(purchase)
                         }
                     }

--- a/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
@@ -1,305 +1,99 @@
 package com.apphud.sdk.internal
 
 import android.content.Context
-import com.apphud.sdk.ApphudInternal
 import com.apphud.sdk.ApphudRuleCallback
-import com.apphud.sdk.internal.data.AnalyticsTracker
-import com.apphud.sdk.internal.data.DeviceIdentifiersDataSource
-import com.apphud.sdk.internal.data.DeviceIdentifiersRepository
-import com.apphud.sdk.internal.data.ProductRepository
-import com.apphud.sdk.internal.data.UserDataSource
-import com.apphud.sdk.internal.data.UserPropertiesManager
-import com.apphud.sdk.internal.data.UserRepository
-import com.apphud.sdk.internal.data.local.LifecycleRepository
-import com.apphud.sdk.internal.data.local.LocalRulesScreenRepository
-import com.apphud.sdk.internal.data.local.PaywallRepository
-import com.apphud.sdk.internal.data.mapper.CustomerMapper
-import com.apphud.sdk.internal.data.mapper.PaywallsMapper
-import com.apphud.sdk.internal.data.mapper.PlacementsMapper
-import com.apphud.sdk.internal.data.mapper.ProductMapper
-import com.apphud.sdk.internal.data.mapper.RenderResultMapper
-import com.apphud.sdk.internal.data.mapper.RuleScreenMapper
-import com.apphud.sdk.internal.data.mapper.SubscriptionMapper
-import com.apphud.sdk.internal.data.network.HeadersInterceptor
-import com.apphud.sdk.internal.data.network.HostSwitcherInterceptor
-import com.apphud.sdk.internal.data.network.HttpRetryInterceptor
-import com.apphud.sdk.internal.data.network.PrettyHttpLoggingInterceptor
-import com.apphud.sdk.internal.data.network.PrettyJsonFormatter
-import com.apphud.sdk.internal.data.network.TimeoutInterceptor
-import com.apphud.sdk.internal.data.network.UrlProvider
-import com.apphud.sdk.internal.data.remote.PurchaseBodyFactory
-import com.apphud.sdk.internal.data.remote.RegistrationBodyFactory
-import com.apphud.sdk.internal.data.remote.RemoteRepository
-import com.apphud.sdk.internal.data.remote.RenderRemoteRepository
-import com.apphud.sdk.internal.data.remote.ScreenRemoteRepository
-import com.apphud.sdk.internal.data.remote.UserRemoteRepository
-import com.apphud.sdk.internal.data.serializer.RenderItemsSerializer
-import com.apphud.sdk.internal.domain.CollectDeviceIdentifiersUseCase
-import com.apphud.sdk.internal.domain.DeviceIdentifiersInteractor
-import com.apphud.sdk.internal.domain.FetchMostActualRuleScreenUseCase
-import com.apphud.sdk.internal.domain.FetchNativePurchasesUseCase
-import com.apphud.sdk.internal.domain.FetchRulesScreenUseCase
-import com.apphud.sdk.internal.domain.RegistrationUseCase
-import com.apphud.sdk.internal.domain.RenderPaywallPropertiesUseCase
-import com.apphud.sdk.internal.domain.ResolveCredentialsUseCase
-import com.apphud.sdk.internal.domain.mapper.DateTimeMapper
-import com.apphud.sdk.internal.domain.mapper.NotificationMapper
 import com.apphud.sdk.internal.domain.model.ApiKey
-import com.apphud.sdk.internal.presentation.rule.RuleController
-import com.apphud.sdk.internal.provider.RegistrationProvider
-import com.apphud.sdk.managers.RequestManager
-import com.apphud.sdk.mappers.AttributionMapper
-import com.apphud.sdk.storage.SharedPreferencesStorage
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
+import kotlinx.coroutines.CoroutineScope
 
-internal class ServiceLocator(
-    private val applicationContext: Context,
-    val ruleCallback: ApphudRuleCallback,
-    private val apiKey: ApiKey,
-) {
+internal class ServiceLocator private constructor() {
 
-    val gson: Gson = Gson()
+    @Volatile
+    private var _appScope: AppScopeComponent? = null
 
-    val storage: SharedPreferencesStorage = SharedPreferencesStorage(applicationContext)
+    @Volatile
+    private var _session: SessionComponent? = null
 
-    private val paywallsMapper = PaywallsMapper(gson)
-    private val placementsMapper = PlacementsMapper(paywallsMapper)
-    private val subscriptionMapper = SubscriptionMapper()
-    private val customerMapper =
-        CustomerMapper(subscriptionMapper, placementsMapper)
+    val appScope: AppScopeComponent
+        get() = _appScope ?: error("App scope not initialized. ApphudInitProvider may have failed to register.")
 
-    val userDataSource: UserDataSource = UserDataSource(storage)
+    val session: SessionComponent
+        get() = _session ?: error("Session not initialized. Call Apphud.start() first.")
 
-    val userRepository: UserRepository = UserRepository(userDataSource)
+    // App-scoped passthrough properties
+    val gson get() = appScope.gson
+    val storage get() = appScope.storage
+    val deviceIdentifiersRepository get() = appScope.deviceIdentifiersRepository
+    val urlProvider get() = appScope.urlProvider
+    val localRulesScreenRepository get() = appScope.localRulesScreenRepository
+    val lifecycleRepository get() = appScope.lifecycleRepository
+    val billingWrapper get() = appScope.billingWrapper
 
-    val deviceIdentifiersDataSource: DeviceIdentifiersDataSource =
-        DeviceIdentifiersDataSource(applicationContext, storage)
-
-    val deviceIdentifiersRepository: DeviceIdentifiersRepository =
-        DeviceIdentifiersRepository(deviceIdentifiersDataSource)
-
-    val analyticsTracker: AnalyticsTracker = AnalyticsTracker(
-        coroutineScope = ApphudInternal.coroutineScope,
-        userRepository = userRepository,
-    )
-
-    private val registrationProvider: RegistrationProvider =
-        RegistrationProvider(
-            applicationContext,
-            deviceIdentifiersRepository,
-            userRepository,
-            analyticsTracker = analyticsTracker)
-
-    internal val urlProvider = UrlProvider()
-
-    private val hostSwitcherInterceptor = HostSwitcherInterceptor(OkHttpClient(), urlProvider)
-    private val hostSwitcherInterceptorWithoutHeaders = HostSwitcherInterceptor(OkHttpClient(), urlProvider)
-
-    private val prettyGson: Gson by lazy {
-        GsonBuilder().setPrettyPrinting().create()
-    }
-    private val prettyJsonFormatter: PrettyJsonFormatter by lazy { PrettyJsonFormatter(prettyGson) }
-    private val prettyLoggingInterceptor: PrettyHttpLoggingInterceptor by lazy {
-        PrettyHttpLoggingInterceptor(prettyJsonFormatter)
-    }
-
-    private val okHttpClient: OkHttpClient =
-        OkHttpClient.Builder()
-            .addInterceptor(
-                HttpLoggingInterceptor().apply {
-                    level =
-                        if (registrationProvider.isSandbox()) {
-                            HttpLoggingInterceptor.Level.BODY
-                        } else {
-                            HttpLoggingInterceptor.Level.BASIC
-                        }
-                }
-            )
-            .addInterceptor(HeadersInterceptor(apiKey))
-            .addInterceptor(TimeoutInterceptor())
-            .addInterceptor(hostSwitcherInterceptor)
-            .addInterceptor(HttpRetryInterceptor())
-            .addInterceptor(prettyLoggingInterceptor)
-            .build()
-
-    private val okHttpClientWithoutHeaders: OkHttpClient =
-        OkHttpClient.Builder()
-            .addInterceptor(
-                HttpLoggingInterceptor().apply {
-                    level =
-                        if (registrationProvider.isSandbox()) {
-                            HttpLoggingInterceptor.Level.BODY
-                        } else {
-                            HttpLoggingInterceptor.Level.BASIC
-                        }
-                }
-            )
-            .addInterceptor(TimeoutInterceptor())
-            .addInterceptor(hostSwitcherInterceptorWithoutHeaders)
-            .addInterceptor(HttpRetryInterceptor())
-            .addInterceptor(prettyLoggingInterceptor)
-            .build()
-
-    val remoteRepository: RemoteRepository =
-        RemoteRepository(
-            okHttpClient = okHttpClient,
-            gson = gson,
-            customerMapper = customerMapper,
-            purchaseBodyFactory = PurchaseBodyFactory(userRepository),
-            registrationBodyFactory = RegistrationBodyFactory(registrationProvider),
-            productMapper = ProductMapper(),
-            attributionMapper = AttributionMapper(),
-            notificationMapper = NotificationMapper(),
-            urlProvider = urlProvider,
-        )
-
-    private val screenRemoteRepository: ScreenRemoteRepository =
-        ScreenRemoteRepository(
-            okHttpClient = okHttpClientWithoutHeaders,
-            gson = gson,
-            apiKey = apiKey
-        )
-
-    val localRulesScreenRepository: LocalRulesScreenRepository =
-        LocalRulesScreenRepository(
-            context = applicationContext,
-            gson = gson,
-            ruleScreenMapper = RuleScreenMapper()
-        )
-
-    val lifecycleRepository: LifecycleRepository = LifecycleRepository()
-
-    val userRemoteRepository: UserRemoteRepository =
-        UserRemoteRepository(
-            okHttpClient = okHttpClient,
-            gson = gson,
-            attributionMapper = AttributionMapper()
-        )
-
-    private val renderResultMapper: RenderResultMapper = RenderResultMapper()
-
-    val renderRemoteRepository: RenderRemoteRepository =
-        RenderRemoteRepository(
-            okHttpClient = okHttpClient,
-            gson = gson,
-            renderResultMapper = renderResultMapper
-        )
-
-    val fetchRulesScreenUseCase: FetchRulesScreenUseCase =
-        FetchRulesScreenUseCase(
-            remoteRepository = remoteRepository,
-            screenRemoteRepository = screenRemoteRepository,
-            localRulesScreenRepository = localRulesScreenRepository,
-            dateTimeMapper = DateTimeMapper(),
-        )
-
-    private val fetchMostActualRuleScreenUseCase: FetchMostActualRuleScreenUseCase =
-        FetchMostActualRuleScreenUseCase(
-            localRulesScreenRepository = localRulesScreenRepository,
-        )
-
-    val renderPaywallPropertiesUseCase: RenderPaywallPropertiesUseCase =
-        RenderPaywallPropertiesUseCase(renderRemoteRepository)
-
-    val paywallRepository: PaywallRepository = PaywallRepository()
-
-    val renderItemsSerializer: RenderItemsSerializer = RenderItemsSerializer(gson)
-
-    val renderResultMapperWithSerializer: RenderResultMapper = RenderResultMapper(renderItemsSerializer)
-
-    val ruleController: RuleController =
-        RuleController(
-            context = applicationContext,
-            fetchRulesScreenUseCase = fetchRulesScreenUseCase,
-            fetchMostActualRuleScreenUseCase = fetchMostActualRuleScreenUseCase,
-            coroutineScope = ApphudInternal.coroutineScope,
-            lifecycleRepository = lifecycleRepository,
-            localRulesScreenRepository = localRulesScreenRepository,
-            ruleCallback = ruleCallback,
-        )
-
-    val paywallEventManager: PaywallEventManager = PaywallEventManager()
-
-    val productRepository: ProductRepository = ProductRepository()
-
-    val userPropertiesManager: UserPropertiesManager = UserPropertiesManager(
-        coroutineScope = ApphudInternal.coroutineScope,
-        userRepository = userRepository,
-        storage = storage,
-        awaitUserRegistration = { ApphudInternal.awaitUserRegistration() },
-    )
-
-    val offeringsCallbackManager: OfferingsCallbackManager = OfferingsCallbackManager(
-        userRepository = userRepository,
-        productRepository = productRepository,
-        analyticsTracker = analyticsTracker,
-    )
-
-    val resolveCredentialsUseCase: ResolveCredentialsUseCase =
-        ResolveCredentialsUseCase(userRepository = userRepository)
-
-    val registrationUseCase: RegistrationUseCase =
-        RegistrationUseCase(
-            userRepository = userRepository,
-            userDataSource = userDataSource,
-            requestManager = RequestManager
-        )
-
-    val collectDeviceIdentifiersUseCase: CollectDeviceIdentifiersUseCase =
-        CollectDeviceIdentifiersUseCase(deviceIdentifiersRepository)
-
-    val deviceIdentifiersInteractor: DeviceIdentifiersInteractor =
-        DeviceIdentifiersInteractor(collectDeviceIdentifiersUseCase, registrationUseCase)
-
-    // Billing dependencies
-    val billingWrapper: BillingWrapper by lazy { BillingWrapper(applicationContext) }
-
-    val fetchNativePurchasesUseCase: FetchNativePurchasesUseCase by lazy {
-        FetchNativePurchasesUseCase(
-            billingWrapper = billingWrapper,
-            userRepository = userRepository,
-        )
-    }
-
-    internal class ServiceLocatorInstanceFactory {
-
-        fun create(
-            applicationContext: Context,
-            ruleCallback: ApphudRuleCallback,
-            apiKey: ApiKey,
-        ): ServiceLocator =
-            synchronized(ServiceLocatorInstanceFactory::class.java) {
-                if (_instance != null) {
-                    error("Instance already exist")
-                }
-
-                ServiceLocator(
-                    applicationContext = applicationContext,
-                    ruleCallback = ruleCallback,
-                    apiKey = apiKey
-                ).also { serviceLocator ->
-                    _instance = serviceLocator
-                }
-            }
-    }
+    // Session-scoped passthrough properties
+    val ruleCallback get() = session.ruleCallback
+    val userDataSource get() = session.userDataSource
+    val userRepository get() = session.userRepository
+    val analyticsTracker get() = session.analyticsTracker
+    val remoteRepository get() = session.remoteRepository
+    val userRemoteRepository get() = session.userRemoteRepository
+    val renderRemoteRepository get() = session.renderRemoteRepository
+    val fetchRulesScreenUseCase get() = session.fetchRulesScreenUseCase
+    val renderPaywallPropertiesUseCase get() = session.renderPaywallPropertiesUseCase
+    val paywallRepository get() = session.paywallRepository
+    val renderItemsSerializer get() = session.renderItemsSerializer
+    val renderResultMapperWithSerializer get() = session.renderResultMapperWithSerializer
+    val ruleController get() = session.ruleController
+    val paywallEventManager get() = session.paywallEventManager
+    val productRepository get() = session.productRepository
+    val userPropertiesManager get() = session.userPropertiesManager
+    val offeringsCallbackManager get() = session.offeringsCallbackManager
+    val resolveCredentialsUseCase get() = session.resolveCredentialsUseCase
+    val registrationUseCase get() = session.registrationUseCase
+    val collectDeviceIdentifiersUseCase get() = session.collectDeviceIdentifiersUseCase
+    val deviceIdentifiersInteractor get() = session.deviceIdentifiersInteractor
+    val fetchNativePurchasesUseCase get() = session.fetchNativePurchasesUseCase
 
     companion object {
         @Volatile
         private var _instance: ServiceLocator? = null
 
+        val instance: ServiceLocator
+            get() = _instance
+                ?: throw IllegalStateException(
+                    "ServiceLocator not initialized. ApphudInitProvider may be missing."
+                )
+
+        @Synchronized
+        fun initAppScope(applicationContext: Context) {
+            val locator = _instance ?: ServiceLocator().also { _instance = it }
+            if (locator._appScope == null) {
+                locator._appScope = AppScopeComponent(applicationContext)
+            }
+        }
+
+        @Synchronized
+        fun initSessionScope(
+            apiKey: ApiKey,
+            ruleCallback: ApphudRuleCallback,
+            coroutineScope: CoroutineScope,
+            awaitUserRegistration: suspend () -> Unit,
+        ) {
+            val locator = instance
+            check(locator._session == null) { "Session already initialized" }
+            locator._session = SessionComponent(
+                appScope = locator.appScope,
+                apiKey = apiKey,
+                ruleCallback = ruleCallback,
+                coroutineScope = coroutineScope,
+                awaitUserRegistration = awaitUserRegistration,
+            )
+        }
+
+        fun clearSession() {
+            _instance?._session = null
+        }
+
         internal fun clearInstance() {
             _instance = null
         }
-
-        val instance: ServiceLocator
-            get() =
-                _instance
-                    ?: throw IllegalStateException(
-                        """To get an instance of the ServiceLocator, you must first call
-                   Apphud.start()""".trimIndent(),
-                    )
     }
 }

--- a/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/ServiceLocator.kt
@@ -3,7 +3,6 @@ package com.apphud.sdk.internal
 import android.content.Context
 import com.apphud.sdk.ApphudRuleCallback
 import com.apphud.sdk.internal.domain.model.ApiKey
-import kotlinx.coroutines.CoroutineScope
 
 internal class ServiceLocator private constructor() {
 
@@ -27,8 +26,10 @@ internal class ServiceLocator private constructor() {
     val localRulesScreenRepository get() = appScope.localRulesScreenRepository
     val lifecycleRepository get() = appScope.lifecycleRepository
     val billingWrapper get() = appScope.billingWrapper
+    val dispatchers get() = appScope.dispatchers
 
     // Session-scoped passthrough properties
+    val coroutineScope get() = session.coroutineScope
     val ruleCallback get() = session.ruleCallback
     val userDataSource get() = session.userDataSource
     val userRepository get() = session.userRepository
@@ -74,7 +75,6 @@ internal class ServiceLocator private constructor() {
         fun initSessionScope(
             apiKey: ApiKey,
             ruleCallback: ApphudRuleCallback,
-            coroutineScope: CoroutineScope,
             awaitUserRegistration: suspend () -> Unit,
         ) {
             val locator = instance
@@ -83,12 +83,12 @@ internal class ServiceLocator private constructor() {
                 appScope = locator.appScope,
                 apiKey = apiKey,
                 ruleCallback = ruleCallback,
-                coroutineScope = coroutineScope,
                 awaitUserRegistration = awaitUserRegistration,
             )
         }
 
         fun clearSession() {
+            _instance?._session?.cancel()
             _instance?._session = null
         }
 

--- a/sdk/src/main/java/com/apphud/sdk/internal/SessionComponent.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/SessionComponent.kt
@@ -1,0 +1,211 @@
+package com.apphud.sdk.internal
+
+import com.apphud.sdk.ApphudRuleCallback
+import com.apphud.sdk.internal.data.AnalyticsTracker
+import com.apphud.sdk.internal.data.ProductRepository
+import com.apphud.sdk.internal.data.UserDataSource
+import com.apphud.sdk.internal.data.UserPropertiesManager
+import com.apphud.sdk.internal.data.UserRepository
+import com.apphud.sdk.internal.data.local.PaywallRepository
+import com.apphud.sdk.internal.data.mapper.ProductMapper
+import com.apphud.sdk.internal.data.mapper.RenderResultMapper
+import com.apphud.sdk.internal.data.network.HeadersInterceptor
+import com.apphud.sdk.internal.data.network.HttpRetryInterceptor
+import com.apphud.sdk.internal.data.network.TimeoutInterceptor
+import com.apphud.sdk.internal.data.remote.PurchaseBodyFactory
+import com.apphud.sdk.internal.data.remote.RegistrationBodyFactory
+import com.apphud.sdk.internal.data.remote.RemoteRepository
+import com.apphud.sdk.internal.data.remote.RenderRemoteRepository
+import com.apphud.sdk.internal.data.remote.ScreenRemoteRepository
+import com.apphud.sdk.internal.data.remote.UserRemoteRepository
+import com.apphud.sdk.internal.data.serializer.RenderItemsSerializer
+import com.apphud.sdk.internal.domain.CollectDeviceIdentifiersUseCase
+import com.apphud.sdk.internal.domain.DeviceIdentifiersInteractor
+import com.apphud.sdk.internal.domain.FetchMostActualRuleScreenUseCase
+import com.apphud.sdk.internal.domain.FetchNativePurchasesUseCase
+import com.apphud.sdk.internal.domain.FetchRulesScreenUseCase
+import com.apphud.sdk.internal.domain.RegistrationUseCase
+import com.apphud.sdk.internal.domain.RenderPaywallPropertiesUseCase
+import com.apphud.sdk.internal.domain.ResolveCredentialsUseCase
+import com.apphud.sdk.internal.domain.mapper.DateTimeMapper
+import com.apphud.sdk.internal.domain.mapper.NotificationMapper
+import com.apphud.sdk.internal.domain.model.ApiKey
+import com.apphud.sdk.internal.presentation.rule.RuleController
+import com.apphud.sdk.internal.provider.RegistrationProvider
+import com.apphud.sdk.managers.RequestManager
+import com.apphud.sdk.mappers.AttributionMapper
+import kotlinx.coroutines.CoroutineScope
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+
+internal class SessionComponent(
+    private val appScope: AppScopeComponent,
+    private val apiKey: ApiKey,
+    val ruleCallback: ApphudRuleCallback,
+    private val coroutineScope: CoroutineScope,
+    awaitUserRegistration: suspend () -> Unit,
+) {
+
+    val userDataSource: UserDataSource = UserDataSource(appScope.storage)
+
+    val userRepository: UserRepository = UserRepository(userDataSource)
+
+    val analyticsTracker: AnalyticsTracker = AnalyticsTracker(
+        coroutineScope = coroutineScope,
+        userRepository = userRepository,
+    )
+
+    private val registrationProvider: RegistrationProvider =
+        RegistrationProvider(
+            appScope.applicationContext,
+            appScope.deviceIdentifiersRepository,
+            userRepository,
+            analyticsTracker = analyticsTracker,
+        )
+
+    private val okHttpClient: OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level =
+                        if (registrationProvider.isSandbox()) {
+                            HttpLoggingInterceptor.Level.BODY
+                        } else {
+                            HttpLoggingInterceptor.Level.BASIC
+                        }
+                }
+            )
+            .addInterceptor(HeadersInterceptor(apiKey))
+            .addInterceptor(TimeoutInterceptor())
+            .addInterceptor(appScope.hostSwitcherInterceptor)
+            .addInterceptor(HttpRetryInterceptor())
+            .addInterceptor(appScope.prettyLoggingInterceptor)
+            .build()
+
+    private val okHttpClientWithoutHeaders: OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level =
+                        if (registrationProvider.isSandbox()) {
+                            HttpLoggingInterceptor.Level.BODY
+                        } else {
+                            HttpLoggingInterceptor.Level.BASIC
+                        }
+                }
+            )
+            .addInterceptor(TimeoutInterceptor())
+            .addInterceptor(appScope.hostSwitcherInterceptorWithoutHeaders)
+            .addInterceptor(HttpRetryInterceptor())
+            .addInterceptor(appScope.prettyLoggingInterceptor)
+            .build()
+
+    val remoteRepository: RemoteRepository =
+        RemoteRepository(
+            okHttpClient = okHttpClient,
+            gson = appScope.gson,
+            customerMapper = appScope.customerMapper,
+            purchaseBodyFactory = PurchaseBodyFactory(userRepository),
+            registrationBodyFactory = RegistrationBodyFactory(registrationProvider),
+            productMapper = ProductMapper(),
+            attributionMapper = AttributionMapper(),
+            notificationMapper = NotificationMapper(),
+            urlProvider = appScope.urlProvider,
+        )
+
+    private val screenRemoteRepository: ScreenRemoteRepository =
+        ScreenRemoteRepository(
+            okHttpClient = okHttpClientWithoutHeaders,
+            gson = appScope.gson,
+            apiKey = apiKey
+        )
+
+    val userRemoteRepository: UserRemoteRepository =
+        UserRemoteRepository(
+            okHttpClient = okHttpClient,
+            gson = appScope.gson,
+            attributionMapper = AttributionMapper()
+        )
+
+    private val renderResultMapper: RenderResultMapper = RenderResultMapper()
+
+    val renderRemoteRepository: RenderRemoteRepository =
+        RenderRemoteRepository(
+            okHttpClient = okHttpClient,
+            gson = appScope.gson,
+            renderResultMapper = renderResultMapper
+        )
+
+    val fetchRulesScreenUseCase: FetchRulesScreenUseCase =
+        FetchRulesScreenUseCase(
+            remoteRepository = remoteRepository,
+            screenRemoteRepository = screenRemoteRepository,
+            localRulesScreenRepository = appScope.localRulesScreenRepository,
+            dateTimeMapper = DateTimeMapper(),
+        )
+
+    private val fetchMostActualRuleScreenUseCase: FetchMostActualRuleScreenUseCase =
+        FetchMostActualRuleScreenUseCase(
+            localRulesScreenRepository = appScope.localRulesScreenRepository,
+        )
+
+    val renderPaywallPropertiesUseCase: RenderPaywallPropertiesUseCase =
+        RenderPaywallPropertiesUseCase(renderRemoteRepository)
+
+    val paywallRepository: PaywallRepository = PaywallRepository()
+
+    val renderItemsSerializer: RenderItemsSerializer = RenderItemsSerializer(appScope.gson)
+
+    val renderResultMapperWithSerializer: RenderResultMapper = RenderResultMapper(renderItemsSerializer)
+
+    val ruleController: RuleController =
+        RuleController(
+            context = appScope.applicationContext,
+            fetchRulesScreenUseCase = fetchRulesScreenUseCase,
+            fetchMostActualRuleScreenUseCase = fetchMostActualRuleScreenUseCase,
+            coroutineScope = coroutineScope,
+            lifecycleRepository = appScope.lifecycleRepository,
+            localRulesScreenRepository = appScope.localRulesScreenRepository,
+            ruleCallback = ruleCallback,
+        )
+
+    val paywallEventManager: PaywallEventManager = PaywallEventManager()
+
+    val productRepository: ProductRepository = ProductRepository()
+
+    val userPropertiesManager: UserPropertiesManager = UserPropertiesManager(
+        coroutineScope = coroutineScope,
+        userRepository = userRepository,
+        storage = appScope.storage,
+        awaitUserRegistration = awaitUserRegistration,
+    )
+
+    val offeringsCallbackManager: OfferingsCallbackManager = OfferingsCallbackManager(
+        userRepository = userRepository,
+        productRepository = productRepository,
+        analyticsTracker = analyticsTracker,
+    )
+
+    val resolveCredentialsUseCase: ResolveCredentialsUseCase =
+        ResolveCredentialsUseCase(userRepository = userRepository)
+
+    val registrationUseCase: RegistrationUseCase =
+        RegistrationUseCase(
+            userRepository = userRepository,
+            userDataSource = userDataSource,
+            requestManager = RequestManager
+        )
+
+    val collectDeviceIdentifiersUseCase: CollectDeviceIdentifiersUseCase =
+        CollectDeviceIdentifiersUseCase(appScope.deviceIdentifiersRepository)
+
+    val deviceIdentifiersInteractor: DeviceIdentifiersInteractor =
+        DeviceIdentifiersInteractor(collectDeviceIdentifiersUseCase, registrationUseCase)
+
+    val fetchNativePurchasesUseCase: FetchNativePurchasesUseCase by lazy {
+        FetchNativePurchasesUseCase(
+            billingWrapper = appScope.billingWrapper,
+            userRepository = userRepository,
+        )
+    }
+}

--- a/sdk/src/main/java/com/apphud/sdk/internal/SessionComponent.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/SessionComponent.kt
@@ -35,16 +35,23 @@ import com.apphud.sdk.internal.provider.RegistrationProvider
 import com.apphud.sdk.managers.RequestManager
 import com.apphud.sdk.mappers.AttributionMapper
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 
 internal class SessionComponent(
-    private val appScope: AppScopeComponent,
+    val appScope: AppScopeComponent,
     private val apiKey: ApiKey,
     val ruleCallback: ApphudRuleCallback,
-    private val coroutineScope: CoroutineScope,
     awaitUserRegistration: suspend () -> Unit,
 ) {
+
+    val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + appScope.dispatchers.io)
+
+    fun cancel() {
+        coroutineScope.cancel()
+    }
 
     val userDataSource: UserDataSource = UserDataSource(appScope.storage)
 
@@ -111,20 +118,23 @@ internal class SessionComponent(
             attributionMapper = AttributionMapper(),
             notificationMapper = NotificationMapper(),
             urlProvider = appScope.urlProvider,
+            dispatchers = appScope.dispatchers,
         )
 
     private val screenRemoteRepository: ScreenRemoteRepository =
         ScreenRemoteRepository(
             okHttpClient = okHttpClientWithoutHeaders,
             gson = appScope.gson,
-            apiKey = apiKey
+            apiKey = apiKey,
+            dispatchers = appScope.dispatchers,
         )
 
     val userRemoteRepository: UserRemoteRepository =
         UserRemoteRepository(
             okHttpClient = okHttpClient,
             gson = appScope.gson,
-            attributionMapper = AttributionMapper()
+            attributionMapper = AttributionMapper(),
+            dispatchers = appScope.dispatchers,
         )
 
     private val renderResultMapper: RenderResultMapper = RenderResultMapper()
@@ -133,7 +143,8 @@ internal class SessionComponent(
         RenderRemoteRepository(
             okHttpClient = okHttpClient,
             gson = appScope.gson,
-            renderResultMapper = renderResultMapper
+            renderResultMapper = renderResultMapper,
+            dispatchers = appScope.dispatchers,
         )
 
     val fetchRulesScreenUseCase: FetchRulesScreenUseCase =
@@ -167,6 +178,7 @@ internal class SessionComponent(
             lifecycleRepository = appScope.lifecycleRepository,
             localRulesScreenRepository = appScope.localRulesScreenRepository,
             ruleCallback = ruleCallback,
+            dispatchers = appScope.dispatchers,
         )
 
     val paywallEventManager: PaywallEventManager = PaywallEventManager()
@@ -178,6 +190,7 @@ internal class SessionComponent(
         userRepository = userRepository,
         storage = appScope.storage,
         awaitUserRegistration = awaitUserRegistration,
+        dispatchers = appScope.dispatchers,
     )
 
     val offeringsCallbackManager: OfferingsCallbackManager = OfferingsCallbackManager(

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/UserPropertiesManager.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/UserPropertiesManager.kt
@@ -5,12 +5,12 @@ import com.apphud.sdk.ApphudLog
 import com.apphud.sdk.ApphudUserProperty
 import com.apphud.sdk.ApphudUserPropertyKey
 import com.apphud.sdk.body.UserPropertiesBody
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.managers.RequestManager
 import com.apphud.sdk.storage.SharedPreferencesStorage
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -22,6 +22,7 @@ internal class UserPropertiesManager(
     private val userRepository: UserRepository,
     private val storage: SharedPreferencesStorage,
     private val awaitUserRegistration: suspend () -> Unit,
+    private val dispatchers: ApphudDispatchers,
 ) {
     private val pendingUserProperties = ConcurrentHashMap<String, ApphudUserProperty>()
 
@@ -130,7 +131,7 @@ internal class UserPropertiesManager(
                 force
             )
 
-            return withContext(Dispatchers.IO) {
+            return withContext(dispatchers.io) {
                 runCatchingCancellable { RequestManager.postUserProperties(body) }
                     .fold(
                         onSuccess = { userProperties ->

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/local/LifecycleRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/local/LifecycleRepository.kt
@@ -5,14 +5,14 @@ import android.os.Looper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.domain.model.LifecycleEvent
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.withContext
 
-internal class LifecycleRepository {
+internal class LifecycleRepository(private val dispatchers: ApphudDispatchers) {
 
     fun get(): Flow<LifecycleEvent> = callbackFlow {
         val lifecycleEventObserver = LifecycleEventObserver { _, event ->
@@ -27,7 +27,7 @@ internal class LifecycleRepository {
             }
         }
 
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main) {
             ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleEventObserver)
         }
 

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/local/LocalRulesScreenRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/local/LocalRulesScreenRepository.kt
@@ -5,9 +5,9 @@ import com.apphud.sdk.ApphudLog
 import com.apphud.sdk.internal.data.dto.RuleScreenDto
 import com.apphud.sdk.internal.data.mapper.RuleScreenMapper
 import com.apphud.sdk.internal.domain.model.RuleScreen
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.google.gson.Gson
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -20,6 +20,7 @@ internal class LocalRulesScreenRepository(
     private val context: Context,
     private val gson: Gson,
     private val ruleScreenMapper: RuleScreenMapper,
+    private val dispatchers: ApphudDispatchers,
 ) {
     private val logPrefix = "[RulesScreenRepo]"
 
@@ -39,7 +40,7 @@ internal class LocalRulesScreenRepository(
     suspend fun save(ruleScreen: RuleScreen): Result<Unit> =
         runCatchingCancellable {
             ApphudLog.log("$logPrefix Saving rule screen with id: ${ruleScreen.rule.id}")
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 fileMutex.withLock {
                     val ruleFile = File(rulesDir, "${ruleScreen.rule.id}.json")
                     FileWriter(ruleFile).use { writer ->
@@ -54,7 +55,7 @@ internal class LocalRulesScreenRepository(
     suspend fun getById(ruleId: String): Result<RuleScreen?> =
         runCatchingCancellable {
             ApphudLog.log("$logPrefix Getting rule screen by id: $ruleId")
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 fileMutex.withLock {
                     val ruleFile = File(rulesDir, "$ruleId.json")
                     if (!ruleFile.exists()) {
@@ -75,7 +76,7 @@ internal class LocalRulesScreenRepository(
     suspend fun getAll(): Result<List<RuleScreen>> =
         runCatchingCancellable {
             ApphudLog.log("$logPrefix Getting all rule screens")
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 fileMutex.withLock {
                     val files = rulesDir.listFiles()
                         ?.filter { it.isFile && it.extension == "json" }
@@ -102,7 +103,7 @@ internal class LocalRulesScreenRepository(
     suspend fun deleteById(ruleId: String): Result<Boolean> =
         runCatchingCancellable {
             ApphudLog.log("$logPrefix Deleting rule screen with id: $ruleId")
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 fileMutex.withLock {
                     val ruleFile = File(rulesDir, "$ruleId.json")
                     if (!ruleFile.exists()) {

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/NetworkUtils.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/NetworkUtils.kt
@@ -5,7 +5,7 @@ import com.apphud.sdk.internal.data.dto.ResponseDto
 import com.apphud.sdk.managers.RequestManager.parser
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
@@ -50,8 +50,9 @@ internal suspend inline fun <reified T> executeForResponse(
     okHttpClient: OkHttpClient,
     gson: Gson,
     request: Request,
+    dispatcher: CoroutineDispatcher,
 ): ResponseDto<T> =
-    withContext(Dispatchers.IO) {
+    withContext(dispatcher) {
         okHttpClient.newCall(request).execute().use { response ->
             val responseBody = response.body?.string()
 

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RemoteRepository.kt
@@ -24,6 +24,7 @@ import com.apphud.sdk.internal.domain.model.GetProductsParams
 import com.apphud.sdk.internal.domain.model.Notification
 import com.apphud.sdk.internal.domain.model.PurchaseContext
 import com.apphud.sdk.internal.util.mapCatchingCancellable
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.data.network.UrlProvider
 import com.apphud.sdk.internal.util.recoverCatchingCancellable
 import com.apphud.sdk.internal.util.runCatchingCancellable
@@ -42,6 +43,7 @@ internal class RemoteRepository(
     private val attributionMapper: AttributionMapper,
     private val notificationMapper: NotificationMapper,
     private val urlProvider: UrlProvider,
+    private val dispatchers: ApphudDispatchers,
 ) {
 
     suspend fun getCustomers(
@@ -53,7 +55,7 @@ internal class RemoteRepository(
         runCatchingCancellable {
             val request =
                 buildPostRequest(urlProvider.customersUrl, registrationBodyFactory.create(needPlacements, isNew, userId, email))
-            executeForResponse<CustomerDto>(okHttpClient, gson, request)
+            executeForResponse<CustomerDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatchingCancellable { e ->
                 val message = e.message ?: "Registration failed"
@@ -69,7 +71,7 @@ internal class RemoteRepository(
         runCatchingCancellable {
             val request =
                 buildPostRequest(urlProvider.subscriptionsUrl, purchaseBodyFactory.create(purchaseContext))
-            executeForResponse<CustomerDto>(okHttpClient, gson, request)
+            executeForResponse<CustomerDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Purchase failed"
@@ -92,7 +94,7 @@ internal class RemoteRepository(
                     urlProvider.subscriptionsUrl,
                     purchaseBodyFactory.create(apphudProduct, purchases, observerMode)
                 )
-            executeForResponse<CustomerDto>(okHttpClient, gson, request)
+            executeForResponse<CustomerDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Restore purchase failed"
@@ -112,7 +114,7 @@ internal class RemoteRepository(
                 "user_id" to getProductsParams.userId,
             )
             val request = buildGetRequest(urlProvider.productsUrl, paramsMap)
-            executeForResponse<List<ApphudGroupDto>>(okHttpClient, gson, request)
+            executeForResponse<List<ApphudGroupDto>>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Parse products failed"
@@ -129,7 +131,7 @@ internal class RemoteRepository(
     ): Result<Attribution> =
         runCatchingCancellable {
             val request = buildPostRequest(urlProvider.attributionUrl, attributionRequestBody)
-            executeForResponse<AttributionDto>(okHttpClient, gson, request)
+            executeForResponse<AttributionDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to send attribution"
@@ -146,7 +148,7 @@ internal class RemoteRepository(
     ): Result<ApphudUser> =
         runCatchingCancellable {
             val request = buildPostRequest(urlProvider.promotionsUrl, grantPromotionalDto)
-            executeForResponse<CustomerDto>(okHttpClient, gson, request)
+            executeForResponse<CustomerDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Promotional grant failed"
@@ -161,7 +163,7 @@ internal class RemoteRepository(
     suspend fun trackEvent(event: PaywallEventDto): Result<Unit> =
         runCatchingCancellable {
             val request = buildPostRequest(urlProvider.eventsUrl, event)
-            executeForResponse<Unit>(okHttpClient, gson, request)
+            executeForResponse<Unit>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to track paywall event"
@@ -175,7 +177,7 @@ internal class RemoteRepository(
                 "device_id" to deviceId,
             )
             val request = buildGetRequest(urlProvider.notificationsUrl, paramsMap)
-            executeForResponse<List<NotificationDto>>(okHttpClient, gson, request)
+            executeForResponse<List<NotificationDto>>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to get notifications"
@@ -194,7 +196,7 @@ internal class RemoteRepository(
                 ruleId = ruleId
             )
             val request = buildPostRequest(urlProvider.notificationsReadUrl, requestDto)
-            executeForResponse<Unit>(okHttpClient, gson, request)
+            executeForResponse<Unit>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to mark notifications as read"

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RenderRemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/RenderRemoteRepository.kt
@@ -5,6 +5,7 @@ import com.apphud.sdk.ApphudError
 import com.apphud.sdk.domain.RenderResult
 import com.apphud.sdk.internal.data.mapper.RenderResultMapper
 import com.apphud.sdk.internal.domain.model.RenderItem
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.google.gson.Gson
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -14,6 +15,7 @@ internal class RenderRemoteRepository(
     private val okHttpClient: OkHttpClient,
     private val gson: Gson,
     private val renderResultMapper: RenderResultMapper,
+    private val dispatchers: ApphudDispatchers,
 ) {
 
     suspend fun renderPaywallProperties(
@@ -22,7 +24,7 @@ internal class RenderRemoteRepository(
         runCatchingCancellable {
             val requestBody = RenderPropertiesRequest(items)
             val request = buildPostRequest(RENDER_PROPERTIES_URL, requestBody)
-            executeForResponse<List<Map<String, Any>>>(okHttpClient, gson, request)
+            executeForResponse<List<Map<String, Any>>>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to render paywall properties"

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/ScreenRemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/ScreenRemoteRepository.kt
@@ -3,10 +3,10 @@ package com.apphud.sdk.internal.data.remote
 import com.apphud.sdk.APPHUD_ERROR_NO_INTERNET
 import com.apphud.sdk.ApphudError
 import com.apphud.sdk.ApphudLog
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.domain.model.ApiKey
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.google.gson.Gson
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
@@ -16,6 +16,7 @@ internal class ScreenRemoteRepository(
     private val okHttpClient: OkHttpClient,
     private val gson: Gson,
     private val apiKey: ApiKey,
+    private val dispatchers: ApphudDispatchers,
 ) {
 
     suspend fun loadScreenHtmlData(screenId: String, deviceId: String): Result<String> =
@@ -31,7 +32,7 @@ internal class ScreenRemoteRepository(
                 .addHeader("APPHUD-API-KEY", apiKey.value)
                 .build()
 
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 okHttpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) {
                         val responseBody = response.body?.string()

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/remote/UserRemoteRepository.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/remote/UserRemoteRepository.kt
@@ -6,6 +6,7 @@ import com.apphud.sdk.body.UserPropertiesBody
 import com.apphud.sdk.domain.Attribution
 import com.apphud.sdk.internal.data.dto.AttributionDto
 import com.apphud.sdk.internal.data.dto.ResponseDto
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.util.runCatchingCancellable
 import com.apphud.sdk.mappers.AttributionMapper
 import com.google.gson.Gson
@@ -16,6 +17,7 @@ internal class UserRemoteRepository(
     private val okHttpClient: OkHttpClient,
     private val gson: Gson,
     private val attributionMapper: AttributionMapper,
+    private val dispatchers: ApphudDispatchers,
 ) {
 
     suspend fun setUserProperties(
@@ -23,7 +25,7 @@ internal class UserRemoteRepository(
     ): Result<Attribution> =
         runCatchingCancellable {
             val request = buildPostRequest(PROPERTIES_URL, userPropertiesBody)
-            executeForResponse<AttributionDto>(okHttpClient, gson, request)
+            executeForResponse<AttributionDto>(okHttpClient, gson, request, dispatchers.io)
         }
             .recoverCatching { e ->
                 val message = e.message ?: "Failed to send properties"

--- a/sdk/src/main/java/com/apphud/sdk/internal/presentation/rule/RuleController.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/presentation/rule/RuleController.kt
@@ -8,6 +8,7 @@ import androidx.core.content.ContextCompat
 import com.apphud.sdk.ApphudLog
 import com.apphud.sdk.ApphudRuleCallback
 import com.apphud.sdk.DeviceId
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.internal.data.local.LifecycleRepository
 import com.apphud.sdk.internal.data.local.LocalRulesScreenRepository
 import com.apphud.sdk.internal.domain.FetchMostActualRuleScreenUseCase
@@ -18,7 +19,6 @@ import com.apphud.sdk.internal.domain.model.LifecycleEvent
 import com.apphud.sdk.internal.domain.model.Rule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -37,6 +37,7 @@ internal class RuleController(
     private val localRulesScreenRepository: LocalRulesScreenRepository,
     coroutineScope: CoroutineScope,
     private val ruleCallback: ApphudRuleCallback,
+    private val dispatchers: ApphudDispatchers,
 ) {
     @Volatile
     private var fetchRuleScreenJob: Job? = null
@@ -86,7 +87,7 @@ internal class RuleController(
                 }
                 is RuleState.RuleActivityClosed -> false
             }
-            withContext(Dispatchers.Main) {
+            withContext(dispatchers.main) {
                 callback(wasShown)
             }
         }
@@ -151,7 +152,7 @@ internal class RuleController(
     }
 
     private suspend fun processPendingRule(pendingRule: Rule) {
-        val shouldShowScreen = withContext(Dispatchers.Main) {
+        val shouldShowScreen = withContext(dispatchers.main) {
             ruleCallback.shouldShowScreen(pendingRule)
         }
         if (shouldShowScreen) {
@@ -174,7 +175,7 @@ internal class RuleController(
                 when (val ruleResult = fetchMostActualRuleScreenUseCase()) {
                     is RuleScreenResult.Success -> {
                         val rule = getRuleById(ruleResult.ruleId) ?: return
-                        val shouldPerformRule = withContext(Dispatchers.Main) {
+                        val shouldPerformRule = withContext(dispatchers.main) {
                             ruleCallback.shouldPerformRule(rule)
                         }
                         if (shouldPerformRule) {

--- a/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
@@ -145,11 +145,12 @@ class ApphudHasPremiumAccessTest {
     }
 
     private fun createServiceLocator() {
-        val factory = ServiceLocator.ServiceLocatorInstanceFactory()
-        factory.create(
-            applicationContext = mockContext,
+        ServiceLocator.initAppScope(mockContext)
+        ServiceLocator.initSessionScope(
+            apiKey = ApiKey("test_api_key"),
             ruleCallback = object : ApphudRuleCallback {},
-            apiKey = ApiKey("test_api_key")
+            coroutineScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO),
+            awaitUserRegistration = {},
         )
     }
 }

--- a/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/ApphudHasPremiumAccessTest.kt
@@ -149,7 +149,6 @@ class ApphudHasPremiumAccessTest {
         ServiceLocator.initSessionScope(
             apiKey = ApiKey("test_api_key"),
             ruleCallback = object : ApphudRuleCallback {},
-            coroutineScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO),
             awaitUserRegistration = {},
         )
     }

--- a/sdk/src/test/java/com/apphud/sdk/internal/data/UserPropertiesManagerTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/data/UserPropertiesManagerTest.kt
@@ -1,6 +1,7 @@
 package com.apphud.sdk.internal.data
 
 import com.apphud.sdk.ApphudUserPropertyKey
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.storage.SharedPreferencesStorage
 import io.mockk.every
 import io.mockk.mockk
@@ -34,6 +35,7 @@ class UserPropertiesManagerTest {
         userRepository = userRepository,
         storage = storage,
         awaitUserRegistration = awaitUserRegistration,
+        dispatchers = ApphudDispatchers(),
     )
 
     // region setUserProperty
@@ -85,6 +87,7 @@ class UserPropertiesManagerTest {
             userRepository = userRepository,
             storage = storage,
             awaitUserRegistration = { gate.await() },
+            dispatchers = ApphudDispatchers(),
         )
         every { userRepository.getCurrentUser() } returns mockk()
         val key = ApphudUserPropertyKey.CustomProperty("test_key")

--- a/sdk/src/test/java/com/apphud/sdk/internal/data/remote/RemoteRepositoryTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/data/remote/RemoteRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.apphud.sdk.internal.data.remote
 
+import com.apphud.sdk.internal.ApphudDispatchers
 import com.apphud.sdk.body.RegistrationBody
 import com.apphud.sdk.domain.ApphudUser
 import com.apphud.sdk.internal.data.dto.CustomerDto
@@ -58,7 +59,8 @@ class RemoteRepositoryTest {
         productMapper = mockk(),
         attributionMapper = mockk(),
         notificationMapper = mockk(),
-        urlProvider = urlProvider
+        urlProvider = urlProvider,
+        dispatchers = ApphudDispatchers(),
     )
 
     private fun createSuccessResponse(): String {


### PR DESCRIPTION
Refactor ServiceLocator: two-tier DI, scope ownership, injectable dispatchers

  Summary

  - Split ServiceLocator into AppScopeComponent and SessionComponent — app-scoped dependencies (storage, billing, device identifiers, mappers) survive
  login/logout cycles; session-scoped dependencies (user repository, HTTP clients, controllers) are destroyed on logout
  - Auto-init via ContentProvider — ApphudInitProvider initializes app-scoped dependencies before Application.onCreate()
  - SessionComponent owns coroutineScope — single source of truth; clearSession() cancels the scope automatically, no manual cancel/recreate needed
  - Removed mainScope — replaced with coroutineScope.launch(dispatchers.main) using injectable ApphudDispatchers
  - Injectable dispatchers everywhere — ApphudDispatchers injected via constructors into all classes; no direct Dispatchers.* usage remains in SDK

  Architecture

  AppScopeComponent (persistent, auto-init via ContentProvider):
  ApphudDispatchers, SharedPreferencesStorage, Gson, mappers, DeviceIdentifiers, BillingWrapper (lazy), LifecycleRepository, LocalRulesScreenRepository,
  UrlProvider, HostSwitcherInterceptor, logging

  SessionComponent (nullable, Apphud.start() → logout()):
  coroutineScope (owned, cancelled on destroy), UserRepository, AnalyticsTracker, OkHttpClient(apiKey), all RemoteRepositories, RuleController,
  PaywallEventManager, UseCases, Interactors

  ServiceLocator — singleton orchestrator with passthrough properties delegating to both components.