### PR TITLE
Map product details before product callbacks

### DIFF
--- a/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
+++ b/sdk/src/main/java/com/apphud/sdk/ApphudInternal.kt
@@ -317,6 +317,7 @@ internal object ApphudInternal {
 
         productDetailsLoaded?.let {
             updateProductState(it)
+            updatePaywallsAndPlacements(it)
 
             // notify that productDetails are loaded
             if (productDetails.isNotEmpty()) {
@@ -911,15 +912,18 @@ internal object ApphudInternal {
         storage.productGroups = groups
     }
 
-    private fun updateGroupsWithProductDetails(productGroups: List<ApphudGroup>) {
+    private fun updateGroupsWithProductDetails(
+        productGroups: List<ApphudGroup>,
+        products: List<ProductDetails> = productDetails,
+    ) {
         productGroups.forEach { group ->
             group.products?.forEach { product ->
-                product.productDetails = getProductDetailsByProductId(product.productId)
+                product.productDetails = getProductDetailsByProductId(product.productId, products)
             }
         }
     }
 
-    private fun updatePaywallsAndPlacements() {
+    private fun updatePaywallsAndPlacements(products: List<ProductDetails> = productDetails) {
         val user = userRepository.getCurrentUser()
         val userPlacements = user?.placements.orEmpty()
 
@@ -932,14 +936,21 @@ internal object ApphudInternal {
                 product.paywallIdentifier = paywall.identifier
                 product.placementId = placement.id
                 product.placementIdentifier = placement.identifier
-                product.productDetails = getProductDetailsByProductId(product.productId)
+                product.productDetails = getProductDetailsByProductId(product.productId, products)
             }
         }
     }
 
     // Find ProductDetails  ======================================
     internal fun getProductDetailsByProductId(productIdentifier: String): ProductDetails? {
-        return productDetails.firstOrNull { it.productId == productIdentifier }
+        return getProductDetailsByProductId(productIdentifier, productDetails)
+    }
+
+    private fun getProductDetailsByProductId(
+        productIdentifier: String,
+        products: List<ProductDetails>,
+    ): ProductDetails? {
+        return products.firstOrNull { it.productId == productIdentifier }
     }
 //endregion
 
@@ -968,7 +979,8 @@ internal object ApphudInternal {
 
     private fun updateProductState(productsLoaded: List<ProductDetails>) {
         productGroups.set(storage.productGroups.orEmpty())
-        updateGroupsWithProductDetails(productGroups.get())
+        val availableProducts = (productsLoaded + productDetails).distinctBy { it.productId }
+        updateGroupsWithProductDetails(productGroups.get(), availableProducts)
     }
     //endregion
 }


### PR DESCRIPTION
## Summary

  This PR makes `ProductDetails` mapping explicit during the product loading completion flow.

  Changes:
  - Maps loaded `ProductDetails` into `ApphudPlacement -> ApphudPaywall -> ApphudProduct` before product-related callbacks are
  fired.
  - Allows placement/paywall product mapping to use the explicit list of just-loaded products instead of relying only on the
  current repository getter.
  - Applies the same explicit product list when updating cached product groups.

  ## Why

  `ProductDetails` are loaded into `ProductRepository` before `notifyLoadingCompleted()` notifies SDK listeners and callback
  managers. Placements and paywalls were already mapped later in the same method, but product-related callbacks could observe the
  loaded products before placement products were refreshed.

  This keeps `ApphudProduct.productDetails` populated earlier for clients that read placements from callbacks such as
  `apphudFetchProductDetails` or `productsFetchCallback`.

  ## Behavior

  The public API is unchanged. The source of truth remains the loaded Billing `ProductDetails`; this PR only makes the mapping
  order and input list more explicit.

  ## Testing

  - `./gradlew :sdk:testDebugUnitTest --tests "com.apphud.sdk.internal.OfferingsCallbackManagerTest"`
  - Manually checked `demo_old`: `ApphudPlacement -> ApphudPaywall -> ApphudProduct.productDetails` is populated after placements/
  products are loaded.