### PR TITLE
[APPHUD-337] Bump version to 3.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-sdkVersion=3.4.2
+sdkVersion=3.5.0
 


### PR DESCRIPTION
Prepares the 3.5.0 release: `sdkVersion` bump in `gradle.properties`. The release contains one feature: `ApphudPaywall.screenName` (#157).
