### PR TITLE
Release 3.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-sdkVersion=3.4.2
+sdkVersion=3.5.0
 

--- a/sdk/src/main/java/com/apphud/sdk/domain/ApphudPaywall.kt
+++ b/sdk/src/main/java/com/apphud/sdk/domain/ApphudPaywall.kt
@@ -60,4 +60,9 @@ data class ApphudPaywall(
      * For internal usage
      */
     internal var placementId: String?,
-)
+) {
+    /**
+     * Name of the paywall's visual Screen as set in the Apphud Dashboard, if the paywall has one.
+     */
+    val screenName: String? get() = screen?.name
+}

--- a/sdk/src/main/java/com/apphud/sdk/domain/ApphudPaywallScreen.kt
+++ b/sdk/src/main/java/com/apphud/sdk/domain/ApphudPaywallScreen.kt
@@ -17,6 +17,12 @@ data class ApphudPaywallScreen(
      */
     @SerializedName("urls")
     private val _urls: Map<String, String>? = null,
+    /**
+     * Screen name as set in the Apphud Dashboard.
+     *
+     * Falls back to `null` for legacy cached data saved before this field existed.
+     */
+    val name: String? = null,
 ) {
     /**
      * Dictionary of localized URLs where key is a locale code ("en", "fr", etc.).

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/dto/ApphudPaywallScreenDto.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/dto/ApphudPaywallScreenDto.kt
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 internal data class ApphudPaywallScreenDto(
     val id: String,
+    val name: String?,
 
     @SerializedName("default_url")
     val defaultURL: String?,

--- a/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/PaywallsMapper.kt
+++ b/sdk/src/main/java/com/apphud/sdk/internal/data/mapper/PaywallsMapper.kt
@@ -39,6 +39,7 @@ internal class PaywallsMapper(
             screen = paywallDto.screen?.let {
                 ApphudPaywallScreen(
                     id = it.id,
+                    name = it.name,
                     defaultUrl = it.defaultURL,
                     _urls = it.urls
                 )

--- a/sdk/src/main/java/com/apphud/sdk/mappers/PaywallsMapperLegacy.kt
+++ b/sdk/src/main/java/com/apphud/sdk/mappers/PaywallsMapperLegacy.kt
@@ -40,6 +40,7 @@ internal class PaywallsMapperLegacy(
             screen = paywallDto.screen?.let {
                 ApphudPaywallScreen(
                     id = it.id,
+                    name = it.name,
                     defaultUrl = it.defaultURL,
                     _urls = it.urls
                 )

--- a/sdk/src/test/java/com/apphud/sdk/internal/data/mapper/PaywallsMapperTest.kt
+++ b/sdk/src/test/java/com/apphud/sdk/internal/data/mapper/PaywallsMapperTest.kt
@@ -1,0 +1,125 @@
+package com.apphud.sdk.internal.data.mapper
+
+import com.apphud.sdk.domain.ApphudPaywallScreen
+import com.apphud.sdk.internal.data.dto.ApphudPaywallDto
+import com.apphud.sdk.internal.data.dto.ApphudPaywallScreenDto
+import com.apphud.sdk.mappers.PaywallsMapperLegacy
+import com.apphud.sdk.parser.GsonParser
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PaywallsMapperTest {
+
+    private val gson = Gson()
+    private val mapper = PaywallsMapper(gson)
+
+    @Test
+    fun `GIVEN screen with name EXPECT paywall screenName filled`() {
+        val paywall = mapper.map(createPaywallDto(screen = createScreenDto(name = "Onboarding paywall")))
+
+        assertEquals("Onboarding paywall", paywall.screen?.name)
+        assertEquals("Onboarding paywall", paywall.screenName)
+    }
+
+    @Test
+    fun `GIVEN screen with null name EXPECT paywall screenName null`() {
+        val paywall = mapper.map(createPaywallDto(screen = createScreenDto(name = null)))
+
+        assertNull(paywall.screenName)
+    }
+
+    @Test
+    fun `GIVEN paywall without screen EXPECT screenName null`() {
+        val paywall = mapper.map(createPaywallDto(screen = null))
+
+        assertNull(paywall.screen)
+        assertNull(paywall.screenName)
+    }
+
+    @Test
+    fun `GIVEN legacy mapper and screen with name EXPECT paywall screenName filled`() {
+        val legacyMapper = PaywallsMapperLegacy(GsonParser(gson))
+
+        val paywall = legacyMapper.map(createPaywallDto(screen = createScreenDto(name = "Onboarding paywall")))
+
+        assertEquals("Onboarding paywall", paywall.screenName)
+    }
+
+    // Backend contract (backend MR !2226): `name` is a nullable string inside the `screen` object.
+    @Test
+    fun `GIVEN screen json with name EXPECT dto name parsed`() {
+        val json = """{"id":"s1","name":"Onboarding paywall","default_url":"https://e.com","urls":{"en":"https://e.com"}}"""
+
+        val dto = gson.fromJson(json, ApphudPaywallScreenDto::class.java)
+
+        assertEquals("Onboarding paywall", dto.name)
+    }
+
+    @Test
+    fun `GIVEN screen json without name key EXPECT dto name null`() {
+        val json = """{"id":"s1","default_url":"https://e.com","urls":{"en":"https://e.com"}}"""
+
+        val dto = gson.fromJson(json, ApphudPaywallScreenDto::class.java)
+
+        assertNull(dto.name)
+    }
+
+    @Test
+    fun `GIVEN screen json with explicit null name EXPECT dto name null`() {
+        val json = """{"id":"s1","name":null,"default_url":"https://e.com","urls":{"en":"https://e.com"}}"""
+
+        val dto = gson.fromJson(json, ApphudPaywallScreenDto::class.java)
+
+        assertNull(dto.name)
+    }
+
+    // The SharedPreferences cache stores DOMAIN models via gson, bypassing DTOs and mappers.
+    @Test
+    fun `GIVEN legacy cached domain screen json without name EXPECT decodes with null name`() {
+        val legacyCacheJson = """{"id":"s1","defaultUrl":"https://e.com","urls":{"en":"https://e.com"}}"""
+
+        val screen = gson.fromJson(legacyCacheJson, ApphudPaywallScreen::class.java)
+
+        assertEquals("https://e.com", screen.defaultUrl)
+        assertNull(screen.name)
+    }
+
+    @Test
+    fun `GIVEN domain screen with name EXPECT name survives cache round-trip`() {
+        val screen = ApphudPaywallScreen(
+            id = "s1",
+            defaultUrl = "https://e.com",
+            _urls = mapOf("en" to "https://e.com"),
+            name = "Onboarding paywall",
+        )
+
+        val restored = gson.fromJson(gson.toJson(screen), ApphudPaywallScreen::class.java)
+
+        assertEquals("Onboarding paywall", restored.name)
+    }
+
+    private fun createScreenDto(name: String?) =
+        ApphudPaywallScreenDto(
+            id = "screen-id",
+            name = name,
+            defaultURL = "https://example.com/en",
+            urls = mapOf("en" to "https://example.com/en"),
+        )
+
+    private fun createPaywallDto(screen: ApphudPaywallScreenDto?) =
+        ApphudPaywallDto(
+            id = "paywall-id",
+            name = "Paywall name",
+            identifier = "main",
+            default = false,
+            json = "{}",
+            items = emptyList(),
+            experimentName = null,
+            variationName = null,
+            variationIdentifier = null,
+            fromPaywall = null,
+            screen = screen,
+        )
+}


### PR DESCRIPTION
## 3.5.0
- Added `screenName` to `ApphudPaywall` and `name` to `ApphudPaywallScreen` — the visual Screen's name from the Apphud Dashboard (#157)

After merge: tag `3.5.0`, Central Portal upload + Publish, JitPack «Get it», GitHub Release.
